### PR TITLE
Add minimal and development version tests

### DIFF
--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -1,0 +1,42 @@
+name: Minimum version tests
+
+on:
+  push:
+    branches:
+      - main
+      - 'stable/**'
+  pull_request:
+    branches:
+      - main
+      - 'stable/**'
+
+jobs:
+  tests:
+    name: minimum version tests (${{ matrix.os }}, ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.12]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies (minimum versions)
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install extremal-python-dependencies==0.0.3
+          pip install "tox==$(extremal-python-dependencies get-tox-minversion)"
+          extremal-python-dependencies pin-dependencies-to-minimum --inplace
+      - name: Test using tox environment
+        shell: bash
+        run: |
+          toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
+          tox -epy${toxpyversion}
+          tox -epy${toxpyversion}-notebook
+          tox -edoctest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Qiskit addon: sample-based quantum diagonalization (SQD)
 
 Qiskit addons are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
-This package contains the Qiskit addon for sample-based quantum diagonalization -- a technique for finding eigenvalues and eigenvectors of quantum operators, such as a quantum system Hamiltonian, using quantum and distributed classical computing together.
+This package contains the Qiskit addon for sample-based quantum diagonalization (SQD) -- a technique for finding eigenvalues and eigenvectors of quantum operators, such as a quantum system Hamiltonian, using quantum and distributed classical computing together.
 
 Classical distributed computing is used to process samples obtained from a quantum processor, and to project and diagonalize a target Hamiltonian in a subspace spanned by them. This allows SQD to be robust to samples corrupted by quantum noise and deal with large Hamiltonians, such as chemistry Hamiltonians with millions of interaction terms, beyond the reach of any exact diagonalization methods.  
 

--- a/docs/tutorials/01_chemistry_hamiltonian.ipynb
+++ b/docs/tutorials/01_chemistry_hamiltonian.ipynb
@@ -5,9 +5,9 @@
    "id": "9e40af77-7f0f-4dd6-ab0a-420cf396050e",
    "metadata": {},
    "source": [
-    "# Improving energy estimation of a Fermionic Hamiltonian with SQD\n",
+    "# Improving energy estimation of a Fermionic Hamiltonian with sample-based quantum diagonalization\n",
     "\n",
-    "In this tutorial we implement a [Qiskit pattern](https://docs.quantum.ibm.com/guides/intro-to-patterns) showing how to post-process noisy quantum samples to find an approximation to the ground state of the $N_2$ molecule at equilibrium in the 6-31G basis set. We will follow a sample-based quantum diagonalization approach [[1]](https://arxiv.org/abs/2405.05068) to process samples taken from a ``36``-qubit quantum circuit. In order to account for the effect of quantum noise, the self-configuration recovery technique is used.\n",
+    "In this tutorial we implement a [Qiskit pattern](https://docs.quantum.ibm.com/guides/intro-to-patterns) showing how to post-process noisy quantum samples to find an approximation to the ground state of the $N_2$ molecule at equilibrium in the 6-31G basis set. We will follow a sample-based quantum diagonalization (SQD) approach [[1]](https://arxiv.org/abs/2405.05068) to process samples taken from a ``36``-qubit quantum circuit. In order to account for the effect of quantum noise, the self-configuration recovery technique is used.\n",
     "\n",
     "The pattern can be described in four steps:\n",
     "\n",


### PR DESCRIPTION
Fixes #1 

- [x] Add minimal version testing
- [ ]  Add development version testing

This PR implements CI tests which run unit and notebook tests against the minimum specified dependency version + the latest supported Python version. It also implements CI tests which run unit and notebook tests against the development branch of core dependencies + the minimum supported Python version