### PR TITLE
docs: correct explanation of ffsim pre-init transpiler passes

### DIFF
--- a/docs/tutorials/01_chemistry_hamiltonian.ipynb
+++ b/docs/tutorials/01_chemistry_hamiltonian.ipynb
@@ -222,7 +222,7 @@
     "\n",
     "- Select physical qubits (`initial_layout`) from the target harware that adheres to the zig-zag pattern described above. Laying out qubits in this pattern leads to an efficient hardware-compatible circuit with less gates.\n",
     "- Generate a staged pass manager using the [generate_preset_pass_manager](https://docs.quantum.ibm.com/api/qiskit/transpiler_preset#generate_preset_pass_manager) function from qiskit with your choice of `backend` and `initial_layout`.\n",
-    "- Set the `pre_init` stage of your staged pass manager to `ffsim.qiskit.PRE_INIT`. `ffsim.qiskit.PRE_INIT` includes qiskit transpiler passes that decompose and merge orbitals resulting in fewer gates in the final circuit.\n",
+    "- Set the `pre_init` stage of your staged pass manager to `ffsim.qiskit.PRE_INIT`. `ffsim.qiskit.PRE_INIT` includes qiskit transpiler passes that decompose gates into orbital rotations and then merges the orbital rotations, resulting in fewer gates in the final circuit.\n",
     "- Run the pass manager on your circuit. "
    ]
   },


### PR DESCRIPTION
It merges orbital rotations, not orbitals.