### PR TITLE
Add qubit functions to the API docs

### DIFF
--- a/qiskit_addon_sqd/qubit.py
+++ b/qiskit_addon_sqd/qubit.py
@@ -18,6 +18,9 @@ Functions for handling quantum samples.
    :toctree: ../stubs/
    :nosignatures:
 
+   solve_qubit
+   project_operator_to_subspace
+   sort_and_remove_duplicates
    matrix_elements_from_pauli
    sort_and_remove_duplicates
 """


### PR DESCRIPTION
Add several functions in the `qubit` module to the API docs.