### PR TITLE
Bump to version 0.4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
 
   deploy:
     name: Deploy docs
-    if: ${{ github.ref == 'refs/heads/stable/0.3' }}
+    if: ${{ github.ref == 'refs/heads/stable/0.4' }}
     needs: build
     permissions:
       pages: write

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,4 +5,4 @@ pull_request_rules:
     actions:
       backport:
         branches:
-          - stable/0.3
+          - stable/0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "qiskit-addon-sqd"
-version = "0.3.0"
+version = "0.4.0"
 readme = "README.md"
 description = "Classically postprocess noisy quantum samples to yield more accurate energy estimations"
 license = {file = "LICENSE.txt"}

--- a/releasenotes/notes/0.4/subsample-hamming-76674dbaf6f411c2.yaml
+++ b/releasenotes/notes/0.4/subsample-hamming-76674dbaf6f411c2.yaml
@@ -1,6 +1,6 @@
 ---
 prelude: >
-    This is a patch release which introduces a couple of small, but important, breaking changes to to the API. These changes allow for a more consistent pattern in specifying the number of alpha and beta electrons throughout both the chemistry and non-chemistry functions in the API.
+    This is a minor release which introduces a couple of small, but important, breaking changes to to the API. These changes allow for a more consistent pattern in specifying the number of alpha and beta electrons throughout both the chemistry and non-chemistry functions in the API.
 
 upgrade:
   - |


### PR DESCRIPTION
Remaining action items:
- [x] Update version [sub]string in all files where it appears in the repository
  - [x] `.mergify.yml`
  - [x] `pyproject.toml`
  - [x] `.github/workflows/docs.yml`
- [x] move release notes to `0.4` directory
- [-] merge everything except this PR on the milestone
- [x] build docs locally; proofread the release notes
- [x] merge this PR
- [ ] tag the release
   1. `git checkout main`
   2. `git pull`
   3. `git show` (verify it's the commit we want to tag)
   4. `git tag -a 0.4.0 -m 0.4.0`
   5. `git show` (double/triple check the tag is on the correct branch)
   6. `git push origin 0.4.0`
- [ ] Wait for CI to finish. The release should then be available on GitHub and pypi.
- [ ] create the `stable/0.4` branch
   1. start with same commit as above checked out
   2. `git checkout -b stable/0.4`
   3. `git show` (check before pushing)
   4. `git push --set-upstream origin stable/0.4`
- [ ] get docs to deploy from the new stable branch (should happen automatically at this point after CI runs both on the new stable branch and then on the `gh-pages` branch)
- [-] move remaining old milestone items to new milestone and close old milestones