### PR TITLE
Set earliest version in reno

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -2,3 +2,4 @@
 encoding: utf8
 default_branch: main
 unreleased_version_title: "Upcoming release"
+earliest_version: 0.4.0


### PR DESCRIPTION
Bump earliest version in reno config to kick off first set of release notes