### PR TITLE
Sort and de-duplicate inside solve_qubit

### DIFF
--- a/docs/tutorials/02_qubit_hamiltonian.ipynb
+++ b/docs/tutorials/02_qubit_hamiltonian.ipynb
@@ -123,27 +123,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**For the projection functions to work as expected, it is essential that the bitstrings that define the subspace are unique and sorted according to their base-10 representation.**\n",
-    "\n",
-    "This can be achieved with the ``qiskit_addon_sqd.qubit.sort_and_remove_duplicates()`` function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from qiskit_addon_sqd.qubit import sort_and_remove_duplicates\n",
-    "\n",
-    "# NOTE: It is essential for the projection code to have the bitstrings sorted!\n",
-    "bitstring_matrix = sort_and_remove_duplicates(bitstring_matrix)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Step 4: Post-process the results\n",
     "\n",
     "Using the [scipy.sparse.linalg.eigsh](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html#eigsh) arguments, we request ``\"k\": 4`` to specify we want ``4`` eigenstates, and we set ``\"which\": \"SA\"`` to specify we want the smallest algebraic eigenstates."
@@ -151,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -239,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -274,8 +253,21 @@
     "\\langle \\sigma^z_i\\rangle \\langle \\sigma^z_{i + l} \\rangle\n",
     "$$\n",
     "\n",
-    "In order to compute the connected spin-spin correlators we first need to compute the \n",
-    "magnetization on each site along the three axes:"
+    "In order to compute the connected spin-spin correlators we first need to compute the  magnetization on each site along the three axes.\n",
+    "\n",
+    "**In order to project qubit operators using [qiskit_addon_sqd.qubit.project_operator_to_subspace](https://qiskit.github.io/qiskit-addon-sqd/stubs/qiskit_addon_sqd.qubit.project_operator_to_subspace.html#qiskit_addon_sqd.qubit.project_operator_to_subspace), the ``bitstring_matrix`` must first be sorted and de-duplicated, or the function will return unexpected results.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit_addon_sqd.qubit import sort_and_remove_duplicates\n",
+    "\n",
+    "# NOTE: It is essential for the projection code to have the bitstrings sorted!\n",
+    "bitstring_matrix = sort_and_remove_duplicates(bitstring_matrix)"
    ]
   },
   {

--- a/qiskit_addon_sqd/qubit.py
+++ b/qiskit_addon_sqd/qubit.py
@@ -72,8 +72,11 @@ def solve_qubit(
     if bitstring_matrix.shape[1] > 63:
         raise ValueError("Bitstrings (rows) in bitstring_matrix must have length < 64.")
 
-    d, _ = bitstring_matrix.shape
+    # Projection requires the bitstring matrix be sorted in accordance with its address representation
+    bitstring_matrix = sort_and_remove_duplicates(bitstring_matrix)
 
+    # Get a sparse representation of the projected operator
+    d, _ = bitstring_matrix.shape
     ham_proj = project_operator_to_subspace(bitstring_matrix, hamiltonian, verbose=verbose)
 
     if verbose:
@@ -167,7 +170,7 @@ def matrix_elements_from_pauli(
 
     .. note::
        The bitstrings in the ``bitstring_matrix`` must be sorted and unique according
-       to their base-10 representation. Otherwise the projection will return wrong
+       to their base-10 address representation. Otherwise the projection will return wrong
        results. This function does not explicitly check for uniqueness and order because
        this can be rather time consuming. See :func:`qiskit_addon_sqd.qubit.sort_and_remove_duplicates`
        for a simple way to ensure your bitstring matrix is well-formatted.


### PR DESCRIPTION
Since ``solve_qubit`` will be a longer-running function for larger problems, let's sort and de-duplicate within the function to ensure expected results are returned. Users should still do their own sorting if using ``project_operator_onto_subspace`` directly to maintain the performance of that function.