### PR TITLE
Support bitstrings longer than 72 bits by removing array2string usage

### DIFF
--- a/qiskit_addon_sqd/configuration_recovery.py
+++ b/qiskit_addon_sqd/configuration_recovery.py
@@ -115,7 +115,7 @@ def recover_configurations(
             num_elec_b,
             rand_seed=rand_seed,
         )
-        bs_str = np.array2string(bs_corrected.astype(int), separator="")[1:-1]
+        bs_str = "".join("1" if bit else "0" for bit in bs_corrected)
         corrected_dict[bs_str] = corrected_dict.get(bs_str, 0.0) + freq
     bs_mat_out = np.array([[bit == "1" for bit in bs] for bs in corrected_dict])
     freqs_out = np.array([f for f in corrected_dict.values()])

--- a/qiskit_addon_sqd/counts.py
+++ b/qiskit_addon_sqd/counts.py
@@ -82,7 +82,7 @@ def generate_counts_uniform(
     bts_matrix = np.random.choice([0, 1], size=(num_samples, num_bits))
     for i in range(num_samples):
         bts_arr = bts_matrix[i, :].astype("int")
-        bts = np.array2string(bts_arr, separator="")[1:-1]
+        bts = "".join("1" if bit else "0" for bit in bts_arr)
         sample_dict[bts] = sample_dict.get(bts, 0) + 1
 
     return sample_dict
@@ -142,7 +142,7 @@ def generate_counts_bipartite_hamming(
         bts_arr[dn_flips] = 1
         bts_arr[up_flips + num_bits // 2] = 1
         bts_arr = bts_arr.astype("int")
-        bts = np.array2string(bts_arr, separator="")[1:-1]
+        bts = "".join("1" if bit else "0" for bit in bts_arr)
 
         # Add the bitstring to the sample dict
         sample_dict[bts] = sample_dict.get(bts, 0) + 1

--- a/releasenotes/notes/no-array2string-efb9b050ca6efc29.yaml
+++ b/releasenotes/notes/no-array2string-efb9b050ca6efc29.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a bug that caused configuration recovery to fail on bitstrings of length greater than 72.

--- a/test/test_configuration_recovery.py
+++ b/test/test_configuration_recovery.py
@@ -93,7 +93,7 @@ class TestConfigurationRecovery(unittest.TestCase):
             )
             self.assertTrue((expected_mat == mat_rec).all())
             self.assertTrue((expected_probs == probs_rec).all())
-        with self.subTest("Test with more than 73 bits. Ones to zeros."):
+        with self.subTest("Test with more than 72 bits. Ones to zeros."):
             n_bits = 74
             rng = np.random.default_rng(554)
             bs_mat = rng.integers(2, size=(1, n_bits), dtype=bool)

--- a/test/test_configuration_recovery.py
+++ b/test/test_configuration_recovery.py
@@ -93,6 +93,21 @@ class TestConfigurationRecovery(unittest.TestCase):
             )
             self.assertTrue((expected_mat == mat_rec).all())
             self.assertTrue((expected_probs == probs_rec).all())
+        with self.subTest("Test with more than 73 bits. Ones to zeros."):
+            n_bits = 74
+            rng = np.random.default_rng(554)
+            bs_mat = rng.integers(2, size=(1, n_bits), dtype=bool)
+            probs = np.array([1.0])
+            occs = np.zeros(n_bits)
+            num_a = 0
+            num_b = 0
+            expected_mat = np.zeros((1, n_bits), dtype=bool)
+            expected_probs = np.array([1.0])
+            mat_rec, probs_rec = recover_configurations(
+                bs_mat, probs, occs, num_a, num_b, rand_seed=4224
+            )
+            self.assertTrue((expected_mat == mat_rec).all())
+            self.assertTrue((expected_probs == probs_rec).all())
         with self.subTest("Bad hamming."):
             bs_mat = np.array([[True, True, True, True]])
             probs = np.array([1.0])


### PR DESCRIPTION
array2string starts to add a newline when the bitstring is longer than 73 bits.

```python
import numpy as np

rng = np.random.default_rng()
bitstring = rng.integers(2, size=74, dtype=bool)
np.array2string(bitstring.astype(int), separator="")[1:-1]
```
```
'0010011001100011100000000001100100000101001111001000000111011101001111011\n 0'
```

The code in this PR is correct, simpler, and also much faster.