### PR TITLE
Fix bugs in optimize_orbitals related to open-shell workflows

### DIFF
--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -231,7 +231,7 @@ def optimize_orbitals(
         )
 
         # Generate the one and two-body reduced density matrices from latest wavefunction amplitudes
-        dm1, dm2_chem = myci.make_rdm12(amplitudes, num_orbitals, (num_up, num_up))
+        dm1, dm2_chem = myci.make_rdm12(amplitudes, num_orbitals, (num_up, num_dn))
         dm2 = np.asarray(dm2_chem.transpose(0, 2, 3, 1), order="C")
 
         # TODO: Expose the momentum parameter as an input option

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -240,7 +240,7 @@ def optimize_orbitals(
             k_flat, learning_rate, 0.9, num_steps_grad, dm1, dm2, hcore, eri_phys
         )
 
-    return e_qsci, k_flat, [np.diagonal(dm1), np.diagonal(dm1)]
+    return e_qsci, k_flat, [np.diagonal(dm1), np.diagonal(dm2_chem)]
 
 
 def rotate_integrals(

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -233,7 +233,7 @@ def optimize_orbitals(
         # Generate the one and two-body reduced density matrices from latest wavefunction amplitudes
         dm1, dm2_chem = myci.make_rdm12(amplitudes, num_orbitals, (num_up, num_dn))
         dm2 = np.asarray(dm2_chem.transpose(0, 2, 3, 1), order="C")
-        dm1a, dm2b = myci.make_rdm1s(amplitudes, num_orbitals, (num_up, num_dn))
+        dm1a, dm1b = myci.make_rdm1s(amplitudes, num_orbitals, (num_up, num_dn))
 
         # TODO: Expose the momentum parameter as an input option
         # Optimize the basis rotations
@@ -241,7 +241,7 @@ def optimize_orbitals(
             k_flat, learning_rate, 0.9, num_steps_grad, dm1, dm2, hcore, eri_phys
         )
 
-    return e_qsci, k_flat, [np.diagonal(dm1a), np.diagonal(dm2b)]
+    return e_qsci, k_flat, [np.diagonal(dm1a), np.diagonal(dm1b)]
 
 
 def rotate_integrals(

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -233,6 +233,7 @@ def optimize_orbitals(
         # Generate the one and two-body reduced density matrices from latest wavefunction amplitudes
         dm1, dm2_chem = myci.make_rdm12(amplitudes, num_orbitals, (num_up, num_dn))
         dm2 = np.asarray(dm2_chem.transpose(0, 2, 3, 1), order="C")
+        dm11, dm22 = myci.make_rdm1s(amplitudes, num_orbitals, (num_up, num_dn))
 
         # TODO: Expose the momentum parameter as an input option
         # Optimize the basis rotations
@@ -240,7 +241,7 @@ def optimize_orbitals(
             k_flat, learning_rate, 0.9, num_steps_grad, dm1, dm2, hcore, eri_phys
         )
 
-    return e_qsci, k_flat, [np.diagonal(dm1), np.diagonal(dm2_chem)]
+    return e_qsci, k_flat, [np.diagonal(dm11), np.diagonal(dm22)]
 
 
 def rotate_integrals(

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -233,7 +233,7 @@ def optimize_orbitals(
         # Generate the one and two-body reduced density matrices from latest wavefunction amplitudes
         dm1, dm2_chem = myci.make_rdm12(amplitudes, num_orbitals, (num_up, num_dn))
         dm2 = np.asarray(dm2_chem.transpose(0, 2, 3, 1), order="C")
-        dm11, dm22 = myci.make_rdm1s(amplitudes, num_orbitals, (num_up, num_dn))
+        dm1a, dm2b = myci.make_rdm1s(amplitudes, num_orbitals, (num_up, num_dn))
 
         # TODO: Expose the momentum parameter as an input option
         # Optimize the basis rotations
@@ -241,7 +241,7 @@ def optimize_orbitals(
             k_flat, learning_rate, 0.9, num_steps_grad, dm1, dm2, hcore, eri_phys
         )
 
-    return e_qsci, k_flat, [np.diagonal(dm11), np.diagonal(dm22)]
+    return e_qsci, k_flat, [np.diagonal(dm1a), np.diagonal(dm2b)]
 
 
 def rotate_integrals(

--- a/releasenotes/notes/oo-bug-occs-3c348b86ee03857f.yaml
+++ b/releasenotes/notes/oo-bug-occs-3c348b86ee03857f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a bug in open-shell workflows where the spin-up/spin-down average orbital occupancies returned from :func:`qiskit_addon_sqd.fermion.optimize_orbitals` both reflected the occupancies of the alpha particles, rather than returning the occupancies of the alpha and beta particles.

--- a/releasenotes/notes/oo-bug-occs-3c348b86ee03857f.yaml
+++ b/releasenotes/notes/oo-bug-occs-3c348b86ee03857f.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fixed a bug in open-shell workflows where the spin-up/spin-down average orbital occupancies returned from :func:`qiskit_addon_sqd.fermion.optimize_orbitals` both reflected the occupancies of the alpha particles, rather than returning the occupancies of the alpha and beta particles.
+    Fixed a bug in open-shell workflows which would cause :func:`qiskit_addon_sqd.fermion.optimize_orbitals` to crash with a ``malloc`` error.


### PR DESCRIPTION
Fixes #70 

Fixes a bug in open-shell workflows causing the spin-up and spin-down average occupancies returned from optimize_orbitals to both reflect the occupancies of the spin-up orbitals, rather than returning both the spin-up and spin-down occupancies.