### PR TITLE
Add support for py39

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           - os: macos-latest
             python-version: "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,14 +97,14 @@ only-include = [
 allow-direct-references = true
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.9"
 show_error_codes = true
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
 
 [tool.pylint.main]
-py-version = "3.10"
+py-version = "3.9"
 
 [tool.pylint."messages control"]
 disable = ["all"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ dependencies = [
     "qiskit>=1.2",
     "numpy>=1.26",
     "pyscf>=2.5",
-    "jaxlib<=0.4.30",
-    "jax<=0.4.30",
-    "scipy<=1.13.1",
+    "jaxlib>=0.4.30",
+    "jax>=0.4.30",
+    "scipy>=1.13.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -21,15 +22,15 @@ classifiers = [
 ]
 
 
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 
 dependencies = [
     "qiskit>=1.2",
     "numpy>=1.26",
     "pyscf>=2.5",
-    "jaxlib>=0.4.31",
-    "jax>=0.4.31",
-    "scipy>=1.14.1",
+    "jaxlib<=0.4.30",
+    "jax<=0.4.30",
+    "scipy<=1.13.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ testpaths = ["./qiskit_addon_sqd/", "./test/"]
 [tool.ruff]
 line-length = 100
 src = ["qiskit_addon_sqd", "test"]
-target-version = "py310"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ only-include = [
 allow-direct-references = true
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 show_error_codes = true
 warn_return_any = true
 warn_unused_configs = true

--- a/qiskit_addon_sqd/configuration_recovery.py
+++ b/qiskit_addon_sqd/configuration_recovery.py
@@ -108,7 +108,7 @@ def recover_configurations(
     # First, we need to flip the orbitals such that
 
     corrected_dict: defaultdict[str, float] = defaultdict(float)
-    for bitstring, freq in zip(bitstring_matrix, probabilities, strict=False):
+    for bitstring, freq in zip(bitstring_matrix, probabilities):
         bs_corrected = _bipartite_bitstring_correcting(
             bitstring,
             avg_occupancies,


### PR DESCRIPTION
Adds support for py39

- [x] Bump `requires-python` in TOML
- [x] Cap versions of `jax` and `scipy`, which have dropped support for py39 in later releases.


Note, the README shield will be updated when we release to PyPI.