### PR TITLE
Add release note about pyscf on Windows

### DIFF
--- a/releasenotes/notes/pyscf-win32-6e4a47d11576aa47.yaml
+++ b/releasenotes/notes/pyscf-win32-6e4a47d11576aa47.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     pyscf is no longer considered a dependency on Windows, where it fails to
-    install.
+    install.  However, Windows remains an unsupported platform.

--- a/releasenotes/notes/pyscf-win32-6e4a47d11576aa47.yaml
+++ b/releasenotes/notes/pyscf-win32-6e4a47d11576aa47.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    pyscf is no longer considered a dependency on Windows, where it fails to
+    install.


### PR DESCRIPTION
0b4558de79f5 drops the pyscf requirement on Windows because it fails to install there.  I pushed that to main hastily and accidentally, when I intended to make a pull request.  This follows that up with a release note, which we should also backport to the stable/0.8 branch because this change is included in the 0.8.1 release.