### PR TITLE
Fix lint errors in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ py-version = "3.9"
 disable = ["all"]
 enable = [
     "reimported",
-    "no-self-use",
     "no-else-raise",
     "redefined-argument-from-local",
     "redefined-builtin",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,9 @@ warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
 
-[tool.pylint.main]
+[tool.pylint]
 py-version = "3.9"
+load-plugins = ["pylint.extensions.no_self_use"]
 
 [tool.pylint."messages control"]
 disable = ["all"]

--- a/qiskit_addon_sqd/counts.py
+++ b/qiskit_addon_sqd/counts.py
@@ -123,10 +123,9 @@ def generate_counts_bipartite_hamming(
         dn_flips = rng.choice(np.arange(num_bits // 2), hamming_left, replace=False).astype("int")
 
         # Create a bitstring with the chosen bits flipped
-        bts_arr = np.zeros(num_bits)
+        bts_arr = np.zeros(num_bits, dtype=int)
         bts_arr[dn_flips] = 1
         bts_arr[up_flips + num_bits // 2] = 1
-        bts_arr = bts_arr.astype("int")  # type: ignore
         bts = "".join("1" if bit else "0" for bit in bts_arr)
 
         # Add the bitstring to the sample dict

--- a/qiskit_addon_sqd/counts.py
+++ b/qiskit_addon_sqd/counts.py
@@ -126,7 +126,7 @@ def generate_counts_bipartite_hamming(
         bts_arr = np.zeros(num_bits)
         bts_arr[dn_flips] = 1
         bts_arr[up_flips + num_bits // 2] = 1
-        bts_arr = bts_arr.astype("int")
+        bts_arr = bts_arr.astype("int")  # type: ignore
         bts = "".join("1" if bit else "0" for bit in bts_arr)
 
         # Add the bitstring to the sample dict


### PR DESCRIPTION
- [x] Initialize this variable with the correct type (int) rather than initializing and then later casting to int

- [x] Resolve warning due to this "no-self-use" flag being useless by loading the check as a plugin
    - ``pyproject.toml:1:0: R0022: Useless option value for '--enable', 'no-self-use' was moved to an optional extension, see https://pylint.readthedocs.io/en/latest/whatsnew/2/2.14/summary.html#removed-checkers. (useless-option-value)``
 