### PR TITLE
Fix indexing bug in recover_configurations

### DIFF
--- a/qiskit_addon_sqd/configuration_recovery.py
+++ b/qiskit_addon_sqd/configuration_recovery.py
@@ -214,11 +214,11 @@ def _bipartite_bitstring_correcting(
 
         if bit_array[i + partition_size]:
             probs_right[i] = _p_flip_1_to_0(
-                hamming_right / partition_size, avg_occupancies[i], 0.01
+                hamming_right / partition_size, avg_occupancies[i + partition_size], 0.01
             )
         else:
             probs_right[i] = _p_flip_0_to_1(
-                hamming_right / partition_size, avg_occupancies[i], 0.01
+                hamming_right / partition_size, avg_occupancies[i + partition_size], 0.01
             )
 
     # Normalize

--- a/releasenotes/notes/fix-indexing-0c49df940710efde.yaml
+++ b/releasenotes/notes/fix-indexing-0c49df940710efde.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fixed an indexing error in :func:`qiskit_addon_sqd.configuration_recovery._bipartite_bitstring_correcting` where the probability array for the right bitstring subsystem, `probs_right`, was constructed incorrectly as the code trasveres the left subsystem instead.
+    Fixed an indexing error in :func:`qiskit_addon_sqd.configuration_recovery` which caused bits in the right half of the bitstring to be flipped with respect to the occupancies of the oritals associated with the left half of the bitstring.

--- a/releasenotes/notes/fix-indexing-0c49df940710efde.yaml
+++ b/releasenotes/notes/fix-indexing-0c49df940710efde.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed an indexing error in :func:`qiskit_addon_sqd.configuration_recovery._bipartite_bitstring_correcting` where the probability array for the right bitstring subsystem, `probs_right`, was constructed incorrectly as the code trasveres the left subsystem instead.


### PR DESCRIPTION
In `_bipartite_bitstring_correcting()` function, the indexing traverses the left subsystem when constructing the probabolity array for the right subsystem. This PR fixes that. 