### PR TITLE
un-deprecate tuple input to solve_fermion

### DIFF
--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 
 import numpy as np
@@ -89,7 +88,7 @@ def solve_fermion(
             configurations should be specified by column indices in range ``(N/2, 0]``, where ``N``
             is the number of qubits.
 
-            (DEPRECATED) The configurations may also be specified by a length-2 tuple of sorted 1D
+            The configurations may also be specified by a length-2 tuple of sorted 1D
             arrays containing unsigned integer representations of the determinants. The two lists
             should represent the spin-up and spin-down orbitals, respectively.
         hcore: Core Hamiltonian matrix representing single-electron integrals
@@ -111,14 +110,8 @@ def solve_fermion(
 
     """
     if isinstance(bitstring_matrix, tuple):
-        warnings.warn(
-            "Passing the input determinants as integers is deprecated. Users should instead pass a bitstring matrix defining the subspace.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         ci_strs = bitstring_matrix
     else:
-        # This will become the default code path after the deprecation period.
         ci_strs = bitstring_matrix_to_ci_strs(bitstring_matrix, open_shell=open_shell)
     ci_strs = _check_ci_strs(ci_strs)
 
@@ -205,7 +198,7 @@ def optimize_orbitals(
             configurations should be specified by column indices in range ``(N/2, 0]``, where ``N``
             is the number of qubits.
 
-            (DEPRECATED) The configurations may also be specified by a length-2 tuple of sorted 1D
+            The configurations may also be specified by a length-2 tuple of sorted 1D
             arrays containing unsigned integer representations of the determinants. The
             two lists should represent the spin-up and spin-down orbitals, respectively.
         hcore: Core Hamiltonian matrix representing single-electron integrals
@@ -238,12 +231,6 @@ def optimize_orbitals(
             f"Expected {num_params}."
         )
     if isinstance(bitstring_matrix, tuple):
-        warnings.warn(
-            "Passing a length-2 tuple of determinant lists to define the spin-up/down subspaces "
-            "is deprecated. Users should instead pass in the bitstring matrix defining the subspaces.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         ci_strs = bitstring_matrix
     else:
         ci_strs = bitstring_matrix_to_ci_strs(bitstring_matrix, open_shell=open_shell)

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -82,15 +82,16 @@ def solve_fermion(
 
     Args:
         bitstring_matrix: A set of configurations defining the subspace onto which the Hamiltonian
-            will be projected and diagonalized. This is a 2D array of ``bool`` representations of bit
-            values such that each row represents a single bitstring. The spin-up configurations
-            should be specified by column indices in range ``(N, N/2]``, and the spin-down
-            configurations should be specified by column indices in range ``(N/2, 0]``, where ``N``
-            is the number of qubits.
+            will be projected and diagonalized.
 
-            The configurations may also be specified by a length-2 tuple of sorted 1D
-            arrays containing unsigned integer representations of the determinants. The two lists
-            should represent the spin-up and spin-down orbitals, respectively.
+            This may be specified in two ways:
+
+            A bitstring matrix: A 2D ``numpy.ndarray`` of ``bool`` representations of bit values such that each row represents a single bitstring. The spin-up
+            configurations should be specified by column indices in range ``(N, N/2]``, and the spin-down configurations should be specified by column
+            indices in range ``(N/2, 0]``, where ``N`` is the number of qubits.
+
+            CI strings: A length-2 tuple of sequences containing integer representations of the spin-up and spin-down determinants, respectively.
+                The expected ordering is ``([a_str_0, ..., a_str_N], [b_str_0, ..., b_str_M])``.
         hcore: Core Hamiltonian matrix representing single-electron integrals
         eri: Electronic repulsion integrals representing two-electron integrals
         open_shell: A flag specifying whether configurations from the left and right
@@ -192,15 +193,16 @@ def optimize_orbitals(
 
     Args:
         bitstring_matrix: A set of configurations defining the subspace onto which the Hamiltonian
-            will be projected and diagonalized. This is a 2D array of ``bool`` representations of bit
-            values such that each row represents a single bitstring. The spin-up configurations
-            should be specified by column indices in range ``(N, N/2]``, and the spin-down
-            configurations should be specified by column indices in range ``(N/2, 0]``, where ``N``
-            is the number of qubits.
+            will be projected and diagonalized.
 
-            The configurations may also be specified by a length-2 tuple of sorted 1D
-            arrays containing unsigned integer representations of the determinants. The
-            two lists should represent the spin-up and spin-down orbitals, respectively.
+            This may be specified in two ways:
+
+            A bitstring matrix: A 2D ``numpy.ndarray`` of ``bool`` representations of bit values such that each row represents a single bitstring. The spin-up
+            configurations should be specified by column indices in range ``(N, N/2]``, and the spin-down configurations should be specified by column
+            indices in range ``(N/2, 0]``, where ``N`` is the number of qubits.
+
+            CI strings: A length-2 tuple of sequences containing integer representations of the spin-up and spin-down determinants, respectively.
+                The expected ordering is ``([a_str_0, ..., a_str_N], [b_str_0, ..., b_str_M])``.
         hcore: Core Hamiltonian matrix representing single-electron integrals
         eri: Electronic repulsion integrals representing two-electron integrals
         k_flat: 1D array defining the orbital transform, ``K``. The array should specify the upper


### PR DESCRIPTION
As suggested in #148 . Not closing that issue because I still think we need to make it easier for the user to construct the tuple input with a desired size.