### PR TITLE
Initialize `bitarray_asint` as `np.int64(0)` to fix type conversion error

### DIFF
--- a/qiskit_addon_sqd/qubit.py
+++ b/qiskit_addon_sqd/qubit.py
@@ -291,7 +291,7 @@ def _int_conversion_from_bts_array(bit_array: np.ndarray) -> Any:
 
     """
     n_qubits = len(bit_array)
-    bitarray_asint = 0.0
+    bitarray_asint = np.int64(0)
     for i in range(n_qubits):
         bitarray_asint = bitarray_asint + bit_array[i] * 2 ** (n_qubits - 1 - i)
 

--- a/releasenotes/notes/fix-bitarray-asint-type-f9b12dd406e604b6.yaml
+++ b/releasenotes/notes/fix-bitarray-asint-type-f9b12dd406e604b6.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fixed a float to integer type conversion error by initializing `bitarray_asint` as `numpy.int64`.
+    Fixed a float to integer type conversion affecting the ``qubit`` module

--- a/releasenotes/notes/fix-bitarray-asint-type-f9b12dd406e604b6.yaml
+++ b/releasenotes/notes/fix-bitarray-asint-type-f9b12dd406e604b6.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed a float to integer type conversion error by initializing `bitarray_asint` as `numpy.int64`.


### PR DESCRIPTION
Fixes #179. 

This PR introduces a single line change to fix bit array to int conversion. 