### PR TITLE
Merge qubit and fermion config recovery

### DIFF
--- a/qiskit_addon_sqd/configuration_recovery.py
+++ b/qiskit_addon_sqd/configuration_recovery.py
@@ -17,34 +17,47 @@ from __future__ import annotations
 
 import warnings
 from collections import defaultdict
-from collections.abc import Sequence
-
+from collections.abc import Sequence, Union, Tuple
 import numpy as np
 
 
 def post_select_by_hamming_weight(
-    bitstring_matrix: np.ndarray, *, hamming_right: int, hamming_left: int
+    bitstring_matrix: np.ndarray,
+    hamming: Union[int, Tuple[int, int]]
 ) -> np.ndarray:
-    """Post-select bitstrings based on the hamming weight of each half.
+    """Post-select bitstrings based on Hamming weight.
 
     Args:
-        bitstring_matrix: A 2D array of ``bool`` representations of bit
-            values such that each row represents a single bitstring
-        hamming_right: The target hamming weight of the right half of bitstrings
-        hamming_left: The target hamming weight of the left half of bitstrings
+        bitstring_matrix: A 2D array of bools where each row is a bitstring.
+        hamming: If int, the target Hamming weight of the whole string.
+                 If tuple (left, right), the target Hamming weights
+                 of the left and right halves, respectively.
 
     Returns:
-        A mask signifying which samples (rows) were selected from the input matrix.
-
+        A 1D bool mask indicating which rows match the criterion.
     """
-    if hamming_left < 0 or hamming_right < 0:
-        raise ValueError("Hamming weights must be non-negative integers.")
+    # Validate and unpack hamming specification
+    if isinstance(hamming, tuple):
+        left, right = hamming
+        if left < 0 or right < 0:
+            raise ValueError("Hamming weights must be non-negative integers.")
+    elif isinstance(hamming, int):
+        if hamming < 0:
+            raise ValueError("Hamming weights must be non-negative integers.")
+    else:
+        raise TypeError("`hamming` must be an int or a tuple of two ints.")
+
     num_bits = bitstring_matrix.shape[1]
 
-    # Find the bitstrings with correct hamming weight on both halves
-    up_keepers = np.sum(bitstring_matrix[:, num_bits // 2 :], axis=1) == hamming_right
-    down_keepers = np.sum(bitstring_matrix[:, : num_bits // 2], axis=1) == hamming_left
-    correct_bs_mask = np.array(np.logical_and(up_keepers, down_keepers))
+    if isinstance(hamming, tuple):
+        # Split the bitstrings in half
+        half = num_bits // 2
+        left_keep = np.sum(bitstring_matrix[:, :half], axis=1) == left
+        right_keep = np.sum(bitstring_matrix[:, half:], axis=1) == right
+        correct_bs_mask = np.logical_and(left_keep, right_keep)
+    else:
+        # Single total Hamming weight over the entire string
+        correct_bs_mask = np.sum(bitstring_matrix, axis=1) == hamming
 
     return correct_bs_mask
 
@@ -52,73 +65,94 @@ def post_select_by_hamming_weight(
 def recover_configurations(
     bitstring_matrix: np.ndarray,
     probabilities: Sequence[float],
-    avg_occupancies: tuple[np.ndarray, np.ndarray],
-    num_elec_a: int,
-    num_elec_b: int,
+    avg_occupancies: Union[np.ndarray, Tuple[np.ndarray, ...]],
+    hamming: Union[int, Tuple[int, int]],
     rand_seed: np.random.Generator | int | None = None,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Refine bitstrings based on average orbital occupancy and a target hamming weight.
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Refine bitstrings based on average occupancy and a target Hamming weight.
 
     This function refines each bit in isolation in an attempt to transform the Hilbert space
     represented by the input ``bitstring_matrix`` into a space closer to that which supports
     the ground state.
 
     .. note::
-
-        This function makes the assumption that bit ``i`` represents the spin-down orbital
-        corresponding to the spin-up orbital in bit ``i + N`` where ``N`` is the number of
-        spatial orbitals and ``i < N``.
+        - If ``hamming`` is a 2-tuple (num_elec_a, num_elec_b), bit ``i`` represents the
+          spin-down orbital corresponding to the spin-up orbital in bit ``i + N`` where
+          ``N`` is the number of spatial orbitals (bipartite spin case).
+        - If ``hamming`` is an int, bit ``i`` represents qubit site ``i`` (single-site case).
 
     Args:
-        bitstring_matrix: A 2D array of ``bool`` representations of bit
-            values such that each row represents a single bitstring
-        probabilities: A 1D array specifying a probability distribution over the bitstrings
-        avg_occupancies: A length-2 tuple of arrays holding the mean occupancy of the spin-up
-            and spin-down orbitals, respectively. The occupancies should be formatted as:
-            ``(array([occ_a_0, ..., occ_a_N]), array([occ_b_0, ..., occ_b_N]))``
-        num_elec_a: The number of spin-up electrons in the system.
-        num_elec_b: The number of spin-down electrons in the system.
-        rand_seed: A seed for controlling randomness
+        bitstring_matrix: A 2D array of ``bool`` values where each row is one bitstring.
+        probabilities: A 1D sequence of floats giving a probability for each row.
+        avg_occupancies: Either
+            * a 1D ``np.ndarray`` of length 2N (deprecated bipartite form), or  
+            * a length-2 tuple ``(occ_up, occ_down)`` of 1D arrays each of length N, or  
+            * a single 1D array of site occupancies (for the single-site case).
+        hamming: If an ``int``, the target total Hamming weight;  
+                 if a ``(num_elec_a, num_elec_b)`` tuple, the bipartite target weights.
+        rand_seed: Seed or ``np.random.Generator`` for stochastic routines.
 
     Returns:
-        A refined bitstring matrix and an updated probability array.
+        A tuple ``(bs_mat_out, freqs_out)`` where
+          - ``bs_mat_out`` is the refined bitstring matrix (shape MxL),
+          - ``freqs_out``   is the normalized frequency array (length M).
 
     References:
-        [1]: J. Robledo-Moreno, et al., `Chemistry Beyond Exact Solutions on a Quantum-Centric Supercomputer <https://arxiv.org/abs/2405.05068>`_,
-             arXiv:2405.05068 [quant-ph].
+        [1]: J. Robledo-Moreno et al., _Chemistry Beyond Exact Solutions on a Quantum-Centric Supercomputer_, arXiv:2405.05068 [quant-ph].
     """
     rng = np.random.default_rng(rand_seed)
 
-    occ_dims = len(np.array(avg_occupancies).shape)
-    if occ_dims == 1:
-        warnings.warn(
-            "Passing avg_occupancies as a 1D array is deprecated. Pass a length-2 tuple containing the spin-up and spin-down occupancies respectively.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        norb = bitstring_matrix.shape[1] // 2
-        avg_occupancies = (np.flip(avg_occupancies[norb:]), np.flip(avg_occupancies[:norb]))
+    # Handle deprecated 1D avg_occupancies for bipartite case
+    if isinstance(avg_occupancies, np.ndarray):
+        if isinstance(hamming, tuple):
+            warnings.warn(
+                "Passing avg_occupancies as a 1D array is deprecated for bipartite spins; "
+                "please supply a length-2 tuple of (occ_up, occ_down).",
+                DeprecationWarning, stacklevel=2
+            )
+            norb = bitstring_matrix.shape[1] // 2
+            avg_occupancies = (
+                np.flip(avg_occupancies[norb:]),
+                np.flip(avg_occupancies[:norb]),
+            )
+        else:
+            warnings.warn(
+                "Passing avg_occupancies as a bare array is accepted but wrapping it "
+                "in a length-1 tuple is preferred for the single-site case.",
+                DeprecationWarning, stacklevel=2
+            )
+            avg_occupancies = (avg_occupancies,)
 
-    if num_elec_a < 0 or num_elec_b < 0:
-        raise ValueError("The numbers of electrons must be specified as non-negative integers.")
+    # Validate avg_occupancies length vs. hamming type
+    if isinstance(avg_occupancies, tuple):
+        if isinstance(hamming, tuple) and len(avg_occupancies) != 2:
+            warnings.warn(
+                f"avg_occupancies should be length-2 for bipartite spins; got {len(avg_occupancies)}.",
+                DeprecationWarning, stacklevel=2
+            )
+        if isinstance(hamming, int) and len(avg_occupancies) != 1:
+            warnings.warn(
+                f"avg_occupancies should be length-1 for single-site; got {len(avg_occupancies)}.",
+                DeprecationWarning, stacklevel=2
+            )
 
-    corrected_dict: defaultdict[str, float] = defaultdict(float)
-    occs_array = np.flip(avg_occupancies).flatten()
-    for bitstring, freq in zip(bitstring_matrix, probabilities):
-        bs_corrected = _bipartite_bitstring_correcting(
-            bitstring,
-            occs_array,
-            num_elec_a,
-            num_elec_b,
-            rng=rng,
-        )
-        bs_str = "".join("1" if bit else "0" for bit in bs_corrected)
-        corrected_dict[bs_str] += freq
-    bs_mat_out = np.array([[bit == "1" for bit in bs] for bs in corrected_dict])
-    freqs_out = np.array([f for f in corrected_dict.values()])
-    freqs_out = np.abs(freqs_out) / np.sum(np.abs(freqs_out))
+    # Flatten occupancy into bit-order
+    occs_array = np.flip(np.array(avg_occupancies)).flatten()
+
+    # Refine each bitstring using the unified corrector
+    corrected: defaultdict[str, float] = defaultdict(float)
+    for bs, freq in zip(bitstring_matrix, probabilities):
+        bs2 = _bitstring_correcting(bs, occs_array, hamming, rng=rng)
+        key = "".join("1" if bit else "0" for bit in bs2)
+        corrected[key] += freq
+
+    # Reconstruct outputs
+    bs_mat_out = np.array([[c == "1" for c in key] for key in corrected])
+    freqs_out  = np.array(list(corrected.values()), dtype=float)
+    freqs_out /= np.sum(np.abs(freqs_out))
 
     return bs_mat_out, freqs_out
+
 
 
 def _p_flip_0_to_1(ratio_exp: float, occ: float, eps: float = 0.01) -> float:  # pragma: no cover
@@ -184,126 +218,106 @@ def _p_flip_1_to_0(ratio_exp: float, occ: float, eps: float = 0.01) -> float:  #
     return occ * slope + intercept
 
 
-def _bipartite_bitstring_correcting(
+
+
+def _bitstring_correcting(
     bit_array: np.ndarray,
     avg_occupancies: np.ndarray,
-    hamming_right: int,
-    hamming_left: int,
+    hamming: Union[int, Tuple[int, int]],
     rng: np.random.Generator,
 ) -> np.ndarray:
-    """Use occupancy information and target hamming weight to correct a bitstring.
+    """Use occupancy information and target Hamming weight(s) to correct a bitstring.
+
+    This function must not mutate the input arrays.
 
     Args:
-        bit_array: A 1D array of ``bool`` representations of bit values
-        avg_occupancies: A 1D array containing the mean occupancy of each orbital.
-        hamming_right: The target hamming weight used for the right half of the bitstring
-        hamming_left: The target hamming weight used for the left half of the bitstring
-        rng: A random number generator
+        bit_array: A 1D array of bools representing the bitstring.
+        avg_occupancies: A 1D array containing the mean occupancy of each site/orbital.
+        hamming:
+            - If int: the total Hamming weight target for the entire bitstring.
+            - If tuple (hamming_left, hamming_right): target weights for left and right halves.
+        rng: A numpy random number generator.
 
     Returns:
-        A corrected bitstring
-
+        A corrected bitstring (new numpy array of bools).
     """
-    # This function must not mutate the input arrays.
     bit_array = bit_array.copy()
-
-    # The number of bits should be even
     num_bits = bit_array.shape[0]
-    partition_size = num_bits // 2
 
-    # Get the probability of flipping each bit, separated into LEFT and RIGHT subsystems,
-    # based on the avg occupancy of each bit and the target hamming weight
+    # Determine whether we're in the bipartite (left/right) or single-case
+    if isinstance(hamming, tuple):
+        hamming_left, hamming_right = hamming
+        if hamming_left < 0 or hamming_right < 0:
+            raise ValueError("Hamming weights must be non-negative integers.")
+        partition_size = num_bits // 2
+        is_bipartite = True
+    else:
+        hamming_weight = hamming
+        if hamming_weight < 0:
+            raise ValueError("Hamming weight must be a non-negative integer.")
+        partition_size = num_bits
+        is_bipartite = False
+
+    # Compute flip probabilities for left half (or full string in single-case)
     probs_left = np.zeros(partition_size)
-    probs_right = np.zeros(partition_size)
     for i in range(partition_size):
+        target = (hamming_left if is_bipartite else hamming_weight) / partition_size
+        occ = avg_occupancies[i]
         if bit_array[i]:
-            probs_left[i] = _p_flip_1_to_0(hamming_left / partition_size, avg_occupancies[i], 0.01)
+            probs_left[i] = _p_flip_1_to_0(target, occ, 0.01)
         else:
-            probs_left[i] = _p_flip_0_to_1(hamming_left / partition_size, avg_occupancies[i], 0.01)
+            probs_left[i] = _p_flip_0_to_1(target, occ, 0.01)
 
-        if bit_array[i + partition_size]:
-            probs_right[i] = _p_flip_1_to_0(
-                hamming_right / partition_size, avg_occupancies[i + partition_size], 0.01
-            )
-        else:
-            probs_right[i] = _p_flip_0_to_1(
-                hamming_right / partition_size, avg_occupancies[i + partition_size], 0.01
-            )
+    # If bipartite, compute for right half too
+    if is_bipartite:
+        probs_right = np.zeros(partition_size)
+        for i in range(partition_size):
+            target = hamming_right / partition_size
+            occ = avg_occupancies[i + partition_size]
+            if bit_array[i + partition_size]:
+                probs_right[i] = _p_flip_1_to_0(target, occ, 0.01)
+            else:
+                probs_right[i] = _p_flip_0_to_1(target, occ, 0.01)
 
-    # Normalize
-    probs_left = np.absolute(probs_left)
-    probs_right = np.absolute(probs_right)
-    probs_left = probs_left / np.sum(probs_left)
-    probs_right = probs_right / np.sum(probs_right)
+    # Normalize probabilities
+    probs_left = np.abs(probs_left)
+    probs_left /= probs_left.sum()
+    if is_bipartite:
+        probs_right = np.abs(probs_right)
+        probs_right /= probs_right.sum()
 
-    ######################## Handle LEFT bits ########################
-
-    # Get difference between # of 1s and expected # of 1s in LEFT bits
+    # Correct LEFT (or full) partition
     n_left = np.sum(bit_array[:partition_size])
-    n_diff = n_left - hamming_left
+    diff_left = n_left - (hamming_left if is_bipartite else hamming_weight)
+    if diff_left > 0:
+        occupied = np.where(bit_array[:partition_size])[0]
+        p_choice = probs_left[bit_array[:partition_size]]
+        p_choice /= p_choice.sum()
+        to_flip = rng.choice(occupied, size=round(diff_left), replace=False, p=p_choice)
+        bit_array[:partition_size][to_flip] = False
+    elif diff_left < 0:
+        empty = np.where(~bit_array[:partition_size])[0]
+        p_choice = probs_left[~bit_array[:partition_size]]
+        p_choice /= p_choice.sum()
+        to_flip = rng.choice(empty, size=round(-diff_left), replace=False, p=p_choice)
+        bit_array[:partition_size][to_flip] = True
 
-    # Too many electrons in LEFT bits
-    if n_diff > 0:
-        indices_occupied = np.where(bit_array[:partition_size])[0]
-        # Get the probabilities that each 1 should be flipped to 0
-        p_choice = probs_left[bit_array[:partition_size]] / np.sum(
-            probs_left[bit_array[:partition_size]]
-        )
-        # Correct the hamming by probabilistically flipping some bits to flip to 0
-        indices_to_flip = rng.choice(
-            indices_occupied, size=round(n_diff), replace=False, p=p_choice
-        )
-        bit_array[:partition_size][indices_to_flip] = False
-
-    # too few electrons in LEFT bits
-    if n_diff < 0:
-        indices_empty = np.where(np.logical_not(bit_array[:partition_size]))[0]
-        # Get the probabilities that each 0 should be flipped to 1
-        p_choice = probs_left[np.logical_not(bit_array[:partition_size])] / np.sum(
-            probs_left[np.logical_not(bit_array[:partition_size])]
-        )
-        # Correct the hamming by probabilistically flipping some bits to flip to 1
-        indices_to_flip = rng.choice(
-            indices_empty, size=round(np.abs(n_diff)), replace=False, p=p_choice
-        )
-        bit_array[:partition_size][indices_to_flip] = np.logical_not(
-            bit_array[:partition_size][indices_to_flip]
-        )
-
-    ######################## Handle RIGHT bits ########################
-
-    # Get difference between # of 1s and expected # of 1s in RIGHT bits
-    n_right = np.sum(bit_array[partition_size:])
-    n_diff = n_right - hamming_right
-
-    # too many electrons in RIGHT bits
-    if n_diff > 0:
-        indices_occupied = np.where(bit_array[partition_size:])[0]
-        # Get the probabilities that each 1 should be flipped to 0
-        p_choice = probs_right[bit_array[partition_size:]] / np.sum(
-            probs_right[bit_array[partition_size:]]
-        )
-        # Correct the hamming by probabilistically flipping some bits to flip to 0
-        indices_to_flip = rng.choice(
-            indices_occupied, size=round(n_diff), replace=False, p=p_choice
-        )
-        bit_array[partition_size:][indices_to_flip] = np.logical_not(
-            bit_array[partition_size:][indices_to_flip]
-        )
-
-    # too few electrons in RIGHT bits
-    if n_diff < 0:
-        indices_empty = np.where(np.logical_not(bit_array[partition_size:]))[0]
-        # Get the probabilities that each 1 should be flipped to 0
-        p_choice = probs_right[np.logical_not(bit_array[partition_size:])] / np.sum(
-            probs_right[np.logical_not(bit_array[partition_size:])]
-        )
-        # Correct the hamming by probabilistically flipping some bits to flip to 1
-        indices_to_flip = rng.choice(
-            indices_empty, size=round(np.abs(n_diff)), replace=False, p=p_choice
-        )
-        bit_array[partition_size:][indices_to_flip] = np.logical_not(
-            bit_array[partition_size:][indices_to_flip]
-        )
+    # If bipartite, correct RIGHT partition
+    if is_bipartite:
+        n_right = np.sum(bit_array[partition_size:])
+        diff_right = n_right - hamming_right
+        if diff_right > 0:
+            occ = np.where(bit_array[partition_size:])[0]
+            p_choice = probs_right[bit_array[partition_size:]]
+            p_choice /= p_choice.sum()
+            to_flip = rng.choice(occ, size=round(diff_right), replace=False, p=p_choice)
+            bit_array[partition_size:][to_flip] = False
+        elif diff_right < 0:
+            empty = np.where(~bit_array[partition_size:])[0]
+            p_choice = probs_right[~bit_array[partition_size:]]
+            p_choice /= p_choice.sum()
+            to_flip = rng.choice(empty, size=round(-diff_right), replace=False, p=p_choice)
+            bit_array[partition_size:][to_flip] = True
 
     return bit_array
+

--- a/qiskit_addon_sqd/subsampling.py
+++ b/qiskit_addon_sqd/subsampling.py
@@ -19,69 +19,82 @@ import numpy as np
 
 from .configuration_recovery import post_select_by_hamming_weight
 
+from collections.abc import Union, Tuple, List
+
 
 def postselect_and_subsample(
     bitstring_matrix: np.ndarray,
     probabilities: np.ndarray,
-    *,
-    hamming_right: int,
-    hamming_left: int,
+    hamming: Union[int, Tuple[int, int]],
     samples_per_batch: int,
     num_batches: int,
     rand_seed: np.random.Generator | int | None = None,
-) -> list[np.ndarray]:
-    """Subsample batches of bit arrays with correct hamming weight from an input ``bitstring_matrix``.
+) -> List[np.ndarray]:
+    """Subsample batches of bitstrings with correct Hamming weight.
 
-    Bitstring samples with incorrect hamming weight on either their left or right half will not
-    be sampled.
+    Uses `post_select_by_hamming_weight` under the hood: if `hamming` is an int, it
+    selects by total weight; if a (left, right) tuple, it selects by left/right halves.
 
-    Each individual batch will be sampled without replacement from the input ``bitstring_matrix``.
-    Samples will be replaced after creation of each batch, so different batches may contain
-    identical samples.
+    Each batch is drawn without replacement from the post-selected pool, but batches
+    themselves may repeat samples.
 
     Args:
-        bitstring_matrix: A 2D array of ``bool`` representations of bit
-            values such that each row represents a single bitstring.
-        probabilities: A 1D array specifying a probability distribution over the bitstrings
-        hamming_right: The target hamming weight for the right half of sampled bitstrings
-        hamming_left: The target hamming weight for the left half of sampled bitstrings
-        samples_per_batch: The number of samples to draw for each batch
-        num_batches: The number of batches to generate
-        rand_seed: A seed to control random behavior
+        bitstring_matrix: 2D bool array where each row is a bitstring.
+        probabilities: 1D array of sampling probabilities (must sum > 0).
+        hamming: If int, the target total Hamming weight;
+                 if (hamming_left, hamming_right), the per-half targets.
+        samples_per_batch: Number of samples per batch (must be > 0).
+        num_batches: Number of batches to generate (must be > 0).
+        rand_seed: Seed or np.random.Generator for RNG.
 
     Returns:
-        A list of bitstring matrices with correct hamming weight subsampled from the input bitstring matrix
+        A list of `num_batches` numpy arrays, each of shape
+        (samples_per_batch, num_bits), containing sampled bitstrings.
 
     Raises:
-        ValueError: The number of elements in ``probabilities`` must equal the number of rows in ``bitstring_matrix``.
-        ValueError: Hamming weights must be non-negative integers.
-        ValueError: Samples per batch and number of batches must be positive integers.
-
+        ValueError: if `probabilities` length ≠ number of rows in `bitstring_matrix`.
+        ValueError: if any Hamming target is negative.
+        ValueError: if `samples_per_batch` or `num_batches` is not positive.
+        TypeError: if `hamming` is neither int nor 2-tuple of ints.
     """
-    num_bitstrings = len(bitstring_matrix)
+    num_bitstrings = bitstring_matrix.shape[0]
     if num_bitstrings == 0:
-        return [np.array([])] * num_batches
-    if len(probabilities) != num_bitstrings:
+        return [np.empty((0, bitstring_matrix.shape[1]), dtype=bool)
+                for _ in range(num_batches)]
+
+    if probabilities.shape[0] != num_bitstrings:
         raise ValueError(
-            "The number of elements in the probabilities array must match the number of rows in the bitstring matrix."
+            "The number of elements in probabilities must match the number of bitstrings."
         )
-    if hamming_left < 0 or hamming_right < 0:
-        raise ValueError("Hamming weight must be specified with a non-negative integer.")
+
+    # Validate hamming
+    if isinstance(hamming, tuple):
+        if len(hamming) != 2 or not all(isinstance(h, int) for h in hamming):
+            raise TypeError("`hamming` tuple must be two ints (hamming_left, hamming_right).")
+        if hamming[0] < 0 or hamming[1] < 0:
+            raise ValueError("Hamming weights must be non-negative integers.")
+    elif isinstance(hamming, int):
+        if hamming < 0:
+            raise ValueError("Hamming weight must be a non-negative integer.")
+    else:
+        raise TypeError("`hamming` must be an int or a tuple of two ints.")
+
+    if samples_per_batch <= 0 or num_batches <= 0:
+        raise ValueError("samples_per_batch and num_batches must be positive integers.")
 
     rng = np.random.default_rng(rand_seed)
 
-    # Post-select only bitstrings with correct hamming weight
-    mask_postsel = post_select_by_hamming_weight(
-        bitstring_matrix, hamming_right=hamming_right, hamming_left=hamming_left
-    )
-    bs_mat_postsel = bitstring_matrix[mask_postsel]
-    probs_postsel = probabilities[mask_postsel]
-    probs_postsel = np.abs(probs_postsel) / np.sum(np.abs(probs_postsel))
+    # Post-select with the unified selector
+    mask = post_select_by_hamming_weight(bitstring_matrix, hamming)
+    bs_sel = bitstring_matrix[mask]
+    probs_sel = probabilities[mask]
+    if probs_sel.size == 0:
+        return [np.empty((0, bitstring_matrix.shape[1]), dtype=bool)
+                for _ in range(num_batches)]
+    probs_sel = np.abs(probs_sel) / np.sum(np.abs(probs_sel))
 
-    if len(probs_postsel) == 0:
-        return [np.array([])] * num_batches
-
-    return subsample(bs_mat_postsel, probs_postsel, samples_per_batch, num_batches, rand_seed=rng)
+    # Delegate to subsample
+    return subsample(bs_sel, probs_sel, samples_per_batch, num_batches, rand_seed=rng)
 
 
 def subsample(


### PR DESCRIPTION
Modifies existing functions for configuration recovery written for fermionic system to work for qubit systems where the total number of particles in conserved (hamming weight of the full bitstring).

It may be a good starting point to think about how to implement the full configuration recovery step in a way that's more configurable to a variety of constraints