### PR TITLE
Allow trailing kwargs in solve_fermion for pyscf solver

### DIFF
--- a/qiskit_addon_sqd/configuration_recovery.py
+++ b/qiskit_addon_sqd/configuration_recovery.py
@@ -138,13 +138,13 @@ def _p_flip_0_to_1(ratio_exp: float, occ: float, eps: float = 0.01) -> float:  #
 
     """
     # Occupancy is < than naive expectation.
-    # Flip 0s to 1 with small (<eps) probability in this case
+    # Flip 0s to 1 with small (~eps) probability in this case
     if occ < ratio_exp:
         return occ * eps / ratio_exp
 
     # Occupancy is >= naive expectation.
-    # The probability weight to flip the bit increases linearly from ``eps`` to
-    # ``1.0`` as the occupation deviates further from the expected ratio
+    # The probability to flip the bit increases linearly from ``eps`` to
+    # ``~1.0`` as the occupation deviates further from the expected ratio
     if ratio_exp == 1.0:
         return eps
     slope = (1 - eps) / (1 - ratio_exp)
@@ -169,18 +169,18 @@ def _p_flip_1_to_0(ratio_exp: float, occ: float, eps: float = 0.01) -> float:  #
 
     """
     # Occupancy is < naive expectation.
-    # The probability weight to flip the bit decreases linearly from ``1.0`` to
-    # ``eps`` as the occupation increases towards the expected ratio
-    if occ < ratio_exp:
-        slope = -(1.0 - eps) / ratio_exp
-        return 1.0 + occ * slope
+    # The probability to flip the bit increases linearly from ``eps`` to
+    # ``~1.0`` as the occupation deviates further from the expected ratio
+    if occ < 1.0 - ratio_exp:
+        slope = (1.0 - eps) / (1.0 - ratio_exp)
+        return 1.0 - occ * slope
 
     # Occupancy is >= naive expectation.
-    # Flip 1s to 0 with small (<eps) probability in this case
+    # Flip 1s to 0 with small (~eps) probability in this case
     if ratio_exp == 0.0:
         return 1 - eps
-    slope = -eps / (1 - ratio_exp)
-    intercept = eps / (1 - ratio_exp)
+    slope = -eps / ratio_exp
+    intercept = eps / ratio_exp
     return occ * slope + intercept
 
 

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -75,8 +75,7 @@ def solve_fermion(
     *,
     open_shell: bool = False,
     spin_sq: float | None = None,
-    max_davidson: int = 100,
-    verbose: int | None = None,
+    **kwargs,
 ) -> tuple[float, SCIState, tuple[np.ndarray, np.ndarray], float]:
     """Approximate the ground state given molecular integrals and a set of electronic configurations.
 
@@ -89,7 +88,6 @@ def solve_fermion(
             A bitstring matrix: A 2D ``numpy.ndarray`` of ``bool`` representations of bit values such that each row represents a single bitstring. The spin-up
             configurations should be specified by column indices in range ``(N, N/2]``, and the spin-down configurations should be specified by column
             indices in range ``(N/2, 0]``, where ``N`` is the number of qubits.
-
             CI strings: A length-2 tuple of sequences containing integer representations of the spin-up and spin-down determinants, respectively.
                 The expected ordering is ``([a_str_0, ..., a_str_N], [b_str_0, ..., b_str_M])``.
         hcore: Core Hamiltonian matrix representing single-electron integrals
@@ -100,8 +98,7 @@ def solve_fermion(
             set of unique configurations and used for both the alpha and beta subspaces.
         spin_sq: Target value for the total spin squared for the ground state.
             If ``None``, no spin will be imposed.
-        max_davidson: The maximum number of cycles of Davidson's algorithm
-        verbose: A verbosity level between 0 and 10
+        **kwargs: Keyword arguments to pass to `pyscf.fci.selected_ci.kernel_fixed_space <https://pyscf.org/pyscf_api_docs/pyscf.fci.html#pyscf.fci.selected_ci.kernel_fixed_space>`_
 
     Returns:
         - Minimum energy from SCI calculation
@@ -135,9 +132,8 @@ def solve_fermion(
         eri,
         norb,
         (num_up, num_dn),
-        ci_strs=ci_strs,
-        verbose=verbose,
-        max_cycle=max_davidson,
+        ci_strs,
+        **kwargs,
     )
 
     # Calculate the avg occupancy of each orbital

--- a/releasenotes/notes/solver-kwargs-49556710c15f645d.yaml
+++ b/releasenotes/notes/solver-kwargs-49556710c15f645d.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    :func:`qiskit_addon_sqd.fermion.solve_fermion` now accepts trailing ``kwargs``, which will be passed directly to `pyscf.fci.selected_ci.kernel_fixed_space <https://pyscf.org/pyscf_api_docs/pyscf.fci.html#pyscf.fci.selected_ci.kernel_fixed_space>`_ in order to calculate the target state.


### PR DESCRIPTION
Fixes #149 

I did not include kwarg descriptions since they are not documented in the pyscf docs. I did provide a link to the function in their docs for reference.

I added a release note bc this is technically a breaking change (albeit a small one). If someone had specified `max_davidson` and/or `verbose` before `spin_sq` or `open_shell`, those arguments would no longer be recognized after this release.