### PR TITLE
Reduce code duplication in `_p_flip_1_to_0`

### DIFF
--- a/qiskit_addon_sqd/configuration_recovery.py
+++ b/qiskit_addon_sqd/configuration_recovery.py
@@ -175,20 +175,7 @@ def _p_flip_1_to_0(ratio_exp: float, occ: float, eps: float = 0.01) -> float:  #
         The probability with which to flip the bit
 
     """
-    # Occupancy is < naive expectation.
-    # The probability weight to flip the bit decreases linearly from ``1.0`` to
-    # ``eps`` as the occupation increases towards the expected ratio
-    if occ < ratio_exp:
-        slope = -(1.0 - eps) / ratio_exp
-        return 1.0 + occ * slope
-
-    # Occupancy is >= naive expectation.
-    # Flip 1s to 0 with small (<eps) probability in this case
-    if ratio_exp == 0.0:
-        return 1 - eps
-    slope = -eps / (1 - ratio_exp)
-    intercept = eps / (1 - ratio_exp)
-    return occ * slope + intercept
+    return _p_flip_0_to_1(1 - ratio_exp, 1 - occ, eps)
 
 
 def _bipartite_bitstring_correcting(


### PR DESCRIPTION
In #185, the `_p_flip_1_to_0` function was updated with the goal of having it be symmetric with the `_p_flip_0_to_1` function.

However, there are some corner cases that are not symmetric yet, such as the following:

```python
>>> from qiskit_addon_sqd.configuration_recovery import _p_flip_0_to_1, _p_flip_1_to_0
>>> _p_flip_1_to_0(0.1, 0.3)
0.0077777777777777776
>>> _p_flip_0_to_1(0.9, 0.7)
0.007777777777777777
>>> _p_flip_1_to_0(0, 0.3)
0.99
>>> _p_flip_0_to_1(1, 0.7)
0.006999999999999999
```

This PR changes `_p_flip_1_to_0` to simply call `_p_flip_0_to_1` with the appropriate parameters, which simplifies (don't repeat yourself) and fixes the above discrepancy.  The output following this change is:

```python
>>> from qiskit_addon_sqd.configuration_recovery import _p_flip_0_to_1, _p_flip_1_to_0
>>> _p_flip_1_to_0(0.1, 0.3)
0.007777777777777777
>>> _p_flip_0_to_1(0.9, 0.7)
0.007777777777777777
>>> _p_flip_1_to_0(0, 0.3)
0.006999999999999999
>>> _p_flip_0_to_1(1, 0.7)
0.006999999999999999
```

This change also fixes #244.