### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -22,7 +21,7 @@ classifiers = [
 ]
 
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "qiskit>=1.2, <3",
@@ -114,7 +113,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 
 [tool.pylint]
-py-version = "3.9"
+py-version = "3.10"
 load-plugins = ["pylint.extensions.no_self_use"]
 
 [tool.pylint."messages control"]


### PR DESCRIPTION
#222 dropped Python 3.9 from CI, but it did not bump the minimum required Python version.  This PR fixes that.

- [ ] Add a release note