### PR TITLE
update sign convention of Pauli Y

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ fn connected_elements_and_amplitudes(
                             total *= -1.0;
                         }
                         if imag_row[j] {
-                            total *= Complex::new(0.0, 1.0);
+                            total *= Complex::new(0.0, -1.0);
                         }
                     }
                     amp_batch[i] = total;


### PR DESCRIPTION
This (very minor) PR attempts to fix the discrepancy in the definition of the Pauli Y operator.

The standard definition is `Y = [[0, -1j], [1j, 0]]`. 

In the current version, when projecting the Y operator into a subspace spanned by [[False], [True]], one obtains the matrix `[[0, 1j], [-1j, 0]] = -Y`. 

I think that the tests did not cover it because of two reasons:

1. In the tutorials we test the Heisenberg model, which contains products of Y operators acting on pairs of qubits -> the sign cancels-out.
2. In the unit tests we only check for the smallest eigenvalue of a single Pauli operator projected into the subspace. This eigenvalue is always -1 regardless of the definition of the sign of Y.