### PR TITLE
Add official support for Python 3.13

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.13"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -20,10 +20,10 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 

--- a/releasenotes/notes/add-py313-2c1e4f8a9b6d7e30.yaml
+++ b/releasenotes/notes/add-py313-2c1e4f8a9b6d7e30.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added support for Python 3.13.

--- a/releasenotes/notes/add-py313-2c1e4f8a9b6d7e30.yaml
+++ b/releasenotes/notes/add-py313-2c1e4f8a9b6d7e30.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Added support for Python 3.13.
+    Added support for Python 3.13. No code changes were necessary, so older releases are expected to work on Python 3.13 too.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.4.3
-envlist = py{310,311,312}{,-notebook}, lint, coverage, docs
+envlist = py{310,311,312,313}{,-notebook}, lint, coverage, docs
 isolated_build = True
 
 [testenv]
@@ -38,7 +38,7 @@ commands =
   nbqa pylint -rn docs/
   reno lint
 
-[testenv:{,py-,py3-,py310-,py311-,py312-}notebook]
+[testenv:{,py-,py3-,py310-,py311-,py312-,py313-}notebook]
 extras =
   nbtest
   notebook-dependencies


### PR DESCRIPTION
## Summary

Adds official support for Python 3.13, following the same pattern used when earlier Python versions were added/dropped (e.g. #256, #83) and matching the configuration of sibling addons such as `qiskit-addon-utils` (which already supports 3.13).

## Changes

- **`pyproject.toml`**: add the `Programming Language :: Python :: 3.13` classifier.
- **`tox.ini`**: extend the `envlist` and the notebook test environment factors to include `py313`.
- **`.github/workflows/test_latest_versions.yml`**: add `3.13` to the matrix and bump the macOS job to `3.13`.
- **`.github/workflows/test_development_versions.yml`**: add `3.13` to the matrix (replacing the previous newest `3.12`).
- **`releasenotes/notes/add-py313-*.yaml`**: release note announcing the new support.

`requires-python` already reads `>=3.10`, so no change is needed there.

## Notes for reviewers

The macOS and development-version newest-Python jobs were bumped from 3.12 → 3.13 to keep testing on the newest supported version, consistent with `qiskit-addon-utils`. Let me know if you'd prefer to keep an explicit 3.12 macOS/dev entry instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)