### PR TITLE
Add official support for Python 3.14

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -20,10 +20,10 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-latest
-            python-version: "3.13"
+            python-version: "3.14"
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 

--- a/releasenotes/notes/add-py313-2c1e4f8a9b6d7e30.yaml
+++ b/releasenotes/notes/add-py313-2c1e4f8a9b6d7e30.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    Added support for Python 3.13. No code changes were necessary, so older releases are expected to work on Python 3.13 too.
+    Added support for Python 3.13 and Python 3.14. No code changes were necessary, so older releases are expected to work on Python 3.13 and 3.14 too.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.4.3
-envlist = py{310,311,312,313}{,-notebook}, lint, coverage, docs
+envlist = py{310,311,312,313,314}{,-notebook}, lint, coverage, docs
 isolated_build = True
 
 [testenv]
@@ -38,7 +38,7 @@ commands =
   nbqa pylint -rn docs/
   reno lint
 
-[testenv:{,py-,py3-,py310-,py311-,py312-,py313-}notebook]
+[testenv:{,py-,py3-,py310-,py311-,py312-,py313-,py314-}notebook]
 extras =
   nbtest
   notebook-dependencies


### PR DESCRIPTION
## Summary

Adds official support for Python 3.14, following the same pattern as the recently merged Python 3.13 PR (#309).

## Changes

- **`pyproject.toml`**: add the `Programming Language :: Python :: 3.14` classifier.
- **`tox.ini`**: extend the `envlist` and the notebook test environment factors to include `py314`.
- **`.github/workflows/test_latest_versions.yml`**: add `3.14` to the matrix and bump the macOS job to `3.14`.
- **`.github/workflows/test_development_versions.yml`**: bump the newest matrix entry from `3.13` to `3.14`.
- **`releasenotes/notes/add-py313-*.yaml`**: updated the existing 3.13 release note to also announce 3.14, rather than adding a separate note.

`requires-python` already reads `>=3.10`, so no change is needed there.

## Notes for reviewers

As with the 3.13 PR, the macOS and development-version newest-Python jobs were bumped to `3.14` to keep testing on the newest supported version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)