### PR TITLE
Fix transpose / Pauli-Y sign error in operator projection

### DIFF
--- a/qiskit_addon_sqd/qubit.py
+++ b/qiskit_addon_sqd/qubit.py
@@ -209,7 +209,7 @@ def matrix_elements_from_pauli(
         raise ValueError("Bitstrings (rows) in bitstring_matrix must have length < 64.")
 
     d, n_qubits = bitstring_matrix.shape
-    row_ids = np.arange(d)
+    input_ids = np.arange(d)
 
     # Get a qubit-wise representation of the Pauli properties
     diag = np.logical_not(pauli.x)[::-1]
@@ -217,28 +217,33 @@ def matrix_elements_from_pauli(
     imag = np.logical_and(pauli.x, pauli.z)[::-1]
 
     # Convert bitstrings to integers
-    int_array_rows = _int_conversion_from_bts_matrix_vmap(bitstring_matrix)
+    int_array_inputs = _int_conversion_from_bts_matrix_vmap(bitstring_matrix)
 
     # The bitstrings in bs_mat_conn are "agreement maps" between the original bitstring
     # and the "diag" operator mask, which guarantees they are unique, since the original
-    # bitstring matrix is expected to be unique.
+    # bitstring matrix is expected to be unique. Each amplitude is the matrix element
+    # <connected element | P | input> for the corresponding input bitstring.
     bs_mat_conn, amplitudes = _connected_elements_and_amplitudes_bool_vmap(
         bitstring_matrix, diag, sign, imag
     )
     # After we calculate the "connected elements" above, we will get the indices
     # of connected elements which appeared in the original set of samples
     int_array_conn = _int_conversion_from_bts_matrix_vmap(bs_mat_conn)
-    conn_ele_mask = np.isin(int_array_conn, int_array_rows, assume_unique=True, kind="sort")
+    conn_ele_mask = np.isin(int_array_conn, int_array_inputs, assume_unique=True, kind="sort")
 
     # Retain configurations which are represented both in the original samples and connected elements
     amplitudes = amplitudes[conn_ele_mask]
     int_array_conn = int_array_conn[conn_ele_mask]
-    row_ids = row_ids[conn_ele_mask]
+    input_ids = input_ids[conn_ele_mask]
 
-    # Get column indices of non-zero matrix elements
-    col_array = np.searchsorted(int_array_rows, int_array_conn)
+    # Index of each connected element among the (sorted) input bitstrings
+    conn_ids = np.searchsorted(int_array_inputs, int_array_conn)
 
-    return amplitudes, row_ids, col_array
+    # Each amplitude is the matrix element <connected | P | input>, so it belongs at
+    # matrix position (row=connected element, col=input). Returning the connected element
+    # as the row index ensures a single Pauli Y projects to Y itself rather than its
+    # transpose -Y (and likewise for any term with an odd number of Y factors).
+    return amplitudes, conn_ids, input_ids
 
 
 def _connected_elements_and_amplitudes_bool(

--- a/releasenotes/notes/fix-pauli-y-projection-sign-6e91d058cd6506bb.yaml
+++ b/releasenotes/notes/fix-pauli-y-projection-sign-6e91d058cd6506bb.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixed a sign error in :func:`~qiskit_addon_sqd.qubit.matrix_elements_from_pauli`
+    (and therefore :func:`~qiskit_addon_sqd.qubit.project_operator_to_subspace` and
+    :func:`~qiskit_addon_sqd.qubit.solve_qubit`) that caused a projected operator to be
+    transposed relative to the input observable.  Because a matrix and its transpose share
+    the same eigenvalues, projected *energies* were unaffected; however, the projected
+    matrix elements -- and hence the recovered eigenstates -- carried the wrong sign for
+    every Pauli term containing an odd number of :math:`Y` operators (since
+    :math:`Y^{T} = -Y`, while :math:`X` and :math:`Z` are symmetric).  A single Pauli
+    :math:`Y` now correctly projects to :math:`Y` rather than :math:`-Y`.

--- a/test/test_qubit.py
+++ b/test/test_qubit.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import pytest
-from qiskit.quantum_info import Pauli, SparsePauliOp
+from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
 from qiskit_addon_sqd.qubit import (
     matrix_elements_from_pauli,
     project_operator_to_subspace,
@@ -46,8 +46,8 @@ class TestQubit(unittest.TestCase):
             # Add an imaginary factor to all qubit msmts corresponding to Y terms
             # Take product of all terms to get component amplitude
             amps_test = np.array([(-1j), (1j)])
-            rows_test = np.array([1, 5])
-            cols_test = np.array([5, 1])
+            rows_test = np.array([5, 1])
+            cols_test = np.array([1, 5])
             num_configs = bs_mat.shape[0]
             coo_matrix_test = coo_matrix(
                 (amps_test, (rows_test, cols_test)), (num_configs, num_configs)
@@ -85,14 +85,16 @@ class TestQubit(unittest.TestCase):
             # Add an imaginary factor to all qubit msmts corresponding to Y terms
             # Take product of all terms to get component amplitude
             amps_test = np.array([(-0.5j), (0.5j)])
-            rows_test = np.array([1, 5])
-            cols_test = np.array([5, 1])
+            rows_test = np.array([5, 1])
+            cols_test = np.array([1, 5])
             num_configs = bs_mat.shape[0]
             coo_matrix_test = coo_matrix(
                 (amps_test, (rows_test, cols_test)), (num_configs, num_configs)
             )
             coo_mat = project_operator_to_subspace(bs_mat, op)
-            self.assertTrue(np.allclose(coo_matrix_test.data, coo_mat.data))
+            # Compare the dense matrices rather than the raw ``.data`` arrays, which are
+            # sensitive to the (arbitrary) storage order of the sparse representation.
+            self.assertTrue(np.allclose(coo_matrix_test.toarray(), coo_mat.toarray()))
             self.assertEqual(coo_matrix_test.shape, coo_mat.shape)
         with self.subTest("64 qubits"):
             op = SparsePauliOp("Z" * 64)
@@ -112,10 +114,10 @@ class TestQubit(unittest.TestCase):
             # Add an imaginary factor to all qubit msmts corresponding to Y terms
             # Take product of all terms to get component amplitude
             amps_test = np.array([(1 + 0j), (-1 + 0j), (1 + 0j), (-1 + 0j)])
-            # All rows represent a connected component to the operator
-            rows_test = np.array([0, 1, 2, 3])
-            # All columns represent a connected component to the operator
-            cols_test = np.array([2, 3, 0, 1])
+            # Rows index the connected element <conn| P |input>; cols index the input
+            rows_test = np.array([2, 3, 0, 1])
+            # All columns represent an input configuration
+            cols_test = np.array([0, 1, 2, 3])
 
             amps, rows, cols = matrix_elements_from_pauli(bs_mat, pauli)
 
@@ -139,8 +141,8 @@ class TestQubit(unittest.TestCase):
             # Add an imaginary factor to all qubit msmts corresponding to Y terms
             # Take product of all terms to get component amplitude
             amps_test = np.array([(-1j), (1j)])
-            rows_test = np.array([1, 5])
-            cols_test = np.array([5, 1])
+            rows_test = np.array([5, 1])
+            cols_test = np.array([1, 5])
             amps, rows, cols = matrix_elements_from_pauli(bs_mat, pauli)
             self.assertTrue(np.allclose(amps_test, amps))
             self.assertTrue(np.allclose(rows_test, rows))
@@ -154,6 +156,38 @@ class TestQubit(unittest.TestCase):
                 e_info.value.args[0]
                 == "Bitstrings (rows) in bitstring_matrix must have length < 64."
             )
+
+    def test_pauli_projection_matches_dense_matrix(self):
+        """Projecting a Pauli onto the full computational subspace must reproduce its dense matrix.
+
+        This guards against a transpose of the projected operator. Because a matrix and
+        its transpose are isospectral, an eigenvalue-only check cannot catch it; and since
+        X, Z (and I) are symmetric, only terms with an *odd* number of Y operators expose
+        the bug (Y^T = -Y).
+        """
+
+        def full_subspace(num_qubits: int) -> np.ndarray:
+            dim = 2**num_qubits
+            return np.array(
+                [[(i >> (num_qubits - 1 - k)) & 1 for k in range(num_qubits)] for i in range(dim)],
+                dtype=bool,
+            )
+
+        # Includes odd-Y terms (Y, XY, YX, XYZ) that are wrong under a transpose,
+        # plus symmetric/even-Y controls (X, Z, XX, YY) that are correct either way.
+        for label in ["X", "Y", "Z", "XX", "XY", "YX", "YY", "XYZ"]:
+            with self.subTest(pauli=label):
+                pauli = Pauli(label)
+                bs_mat = full_subspace(len(label))
+                op = SparsePauliOp([label], coeffs=[1.0])
+
+                projected = project_operator_to_subspace(bs_mat, op).toarray()
+                expected = Operator(pauli).to_matrix()
+
+                self.assertTrue(
+                    np.allclose(projected, expected),
+                    msg=f"Projected {label} does not match its dense matrix:\n{projected}\n!=\n{expected}",
+                )
 
     def test_sort_and_remove_duplicates(self):
         with self.subTest("Basic test"):


### PR DESCRIPTION
This PR was created by Claude Opus 4.8 while determining what next steps should be for #262. At first it claimed that there was no issue, but later it claimed that there was. So this should be inspected carefully from a human perspective.

---

## Summary

This supersedes #262. #262 correctly identified that a single Pauli `Y` projects to `-Y`, but it patched the Rust `src/lib.rs` that was since removed (reverted in #280), and its proposed fix (flipping the imaginary factor to `-1j`) addresses the symptom by conjugation rather than the actual cause.

The actual bug is a **transpose** of the projected operator, in the Python path that ships today.

## Root cause

In `matrix_elements_from_pauli`, the amplitude computed for an input bitstring `b` is the matrix element `<conn|P|b>`, but it was stored at sparse-matrix position `[row=b, col=conn]` (i.e. row=input, col=output). The correct home for `<conn|P|b>` is `[row=conn, col=b]`. Row and column were swapped, transposing the result.

Since `X^T = X` and `Z^T = Z` but `Y^T = -Y`, the transpose flips the sign of **every Pauli term containing an odd number of `Y` operators**. Verified end-to-end against `qiskit.quantum_info.Operator`:

| operator | # of Y | before |
|---|---|---|
| `Y`, `XY`, `YX`, `XYZ` | odd | comes out as `-P` |
| `YY`, `XX`, `X`, `Z`, `I` | even/zero | correct |

## Impact

A matrix and its transpose are **isospectral**, so projected **energies were never affected** — which is why this survived: every existing test checks only eigenvalues. The error corrupted the projected **matrix elements / recovered eigenstates** for odd-`Y` terms only.

## The fix

Return the connected element as the row index and the input as the column in `matrix_elements_from_pauli`. Consumers (`project_operator_to_subspace`, `solve_qubit`) inherit the fix unchanged. Variables were renamed (`row_ids` → `input_ids`, `col_array` → `conn_ids`) so the row/column convention is explicit rather than implied — the old names are what made the bug invisible in review.

## Tests

- New `test_pauli_projection_matches_dense_matrix`: reconstructs the projection over the full computational subspace and compares to `Operator(pauli).to_matrix()` for `X, Y, Z, XX, XY, YX, YY, XYZ`. Confirmed to **fail on `main`** exactly on the odd-`Y` terms and pass after the fix. An eigenvalue-only test cannot catch a transpose; this one can.
- Updated three existing tests whose hardcoded `rows_test`/`cols_test` encoded the buggy convention.
- Changed `test_project_operator_to_subspace` to compare dense matrices rather than order-sensitive sparse `.data` arrays (the old comparison only matched by coincidence of storage order).

All `test_qubit.py` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)