### PR TITLE
Add guide about multi-process and multi-threaded acceleration

### DIFF
--- a/docs/guides/hpc_acceleration.rst
+++ b/docs/guides/hpc_acceleration.rst
@@ -22,14 +22,16 @@ This package supports collective multi-process acceleration in the
 single-program, multiple-data (SPMD) style, in which the entire program is
 launched as multiple isolated processes that run with explicit global
 synchronization and communication between them (for example,
-``mpirun -n 128 python my_program.py``). While the API of this package is
-designed to be general, the current implementation relies on MPI,
-the standard message-passing API for HPC systems.  Regardless of implementation,
-this package makes the assumption that there is a single thread controlling
-each process. In the case of MPI, this corresponds to ``MPI_THREAD_FUNNELED`` or lower.
-Because it composes cleanly with job schedulers and other parallel software and
-scales to large process counts, this is the recommended model for
-high-performance and large-scale workloads, and it is the subject of this page.
+``mpirun -n 128 python my_program.py``). Because the SPMD style composes cleanly
+with job schedulers and other parallel software and scales to large process
+counts, it is the recommended model for high-performance and large-scale
+workloads, and it is the subject of this page.
+
+Although this package is designed to accommodate different collective-execution
+backends, its current implementation targets MPI, the standard message-passing
+API for HPC systems. Regardless of implementation, this package assumes that a
+single thread controls each process. In the case of MPI, this corresponds to
+``MPI_THREAD_FUNNELED`` or lower.
 
 Only one function currently supports being called collectively from all
 processes: :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian`.
@@ -38,13 +40,13 @@ participate and contribute work, so an eigensolver implementation can use
 every process. The remaining parts of the configuration-recovery loop have no
 distributed implementation and run on the control process (rank 0) only.
 
-Some existing eigensolver implementations instead require the calling program
-to be outside an MPI/SPMD environment, as they launch and manage their own parallel processes internally, for
-example by invoking ``mpirun`` on the user's behalf. That mode is convenient
-for interactive and notebook-based work and remains supported; its requirements
-on the calling program are described in the API reference of the
-:func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` function,
-which accepts such a solver.
+Some existing eigensolver implementations instead require the calling program to
+run outside an MPI/SPMD environment, because they launch and manage their own
+parallel processes internally, for example by invoking ``mpirun`` on the user's
+behalf. That mode is convenient for interactive and notebook-based work and
+remains supported; its requirements on the calling program are described in the
+API reference of the
+:func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` function.
 
 Every other API in this package must be called from the control
 process alone, on its own local data, and carries no collective semantics.
@@ -80,7 +82,7 @@ exception---but this can only be provided on a best-effort basis and must not be
 relied upon for correctness or recovery.
 
 These are properties that a collective implementation is permitted to have, not
-guarantees about any particular one. In this package, the only collective entry
-point is ``sci_solver`` (see the preceding section); its default implementation is not
-distributed, so these considerations apply to a custom, collective
-``sci_solver`` supplied by the user.
+guarantees about any particular one. In this package, the only collective step
+is the eigensolver (see the preceding section); its default implementation is
+not distributed, so these considerations apply to a custom, collective
+eigensolver supplied by the user.

--- a/docs/guides/hpc_acceleration.rst
+++ b/docs/guides/hpc_acceleration.rst
@@ -48,9 +48,6 @@ remains supported; its requirements on the calling program are described in the
 API reference of the
 :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` function.
 
-Every other API in this package must be called from the control
-process alone, on its own local data, and carries no collective semantics.
-
 The return value and synchronization semantics of a collective function
 belong with that function, so they are documented in its API reference.
 In general, the documentation of any collective function

--- a/docs/guides/hpc_acceleration.rst
+++ b/docs/guides/hpc_acceleration.rst
@@ -31,18 +31,18 @@ participate and contribute work, so an eigensolver implementation can use
 every process. The remaining parts of the configuration-recovery loop have no
 distributed implementation and run on the control process (rank 0) only.
 
-Every other API in this package is intended to be called from the control
+Every other API in this package must be called from the control
 process alone, on its own local data, and carries no collective semantics.
 
-The precise return-value and synchronization semantics of a collective function
-belong with that function, so they are documented in its API reference rather
-than repeated here. In general, the documentation of any collective function
+The return value and synchronization semantics of a collective function
+belong with that function, so they are documented in its API reference.
+In general, the documentation of any collective function
 should make clear:
 
-- whether the function is meant to be called independently by each process on
-  its own local data, or collectively by all processes;
-- how its arguments must agree across processes;
-- and how its return value is delivered---whether the result exists only on the
+- Whether the function is meant to be called independently by each process on
+  its own local data, or collectively by all processes.
+- How its arguments must agree across processes.
+- How its return value is delivered---whether the result exists only on the
   control process, whether all processes receive the same value, or whether
   each process receives a handle to a local portion of a distributed data
   structure.
@@ -55,7 +55,7 @@ exception or abort only a single process, because that would leave the
 remaining processes deadlocked or in an inconsistent state. Instead, error
 handling follows fail-stop semantics for the execution context as a whole: upon
 an error, the implementation must be prepared to abort the entire execution
-context collectively (for example, via ``MPI_Abort``).
+context collectively (for example, by using ``MPI_Abort``).
 
 The API cannot guarantee coordinated error reporting or collective delivery of
 exceptions across processes, because MPI implementations do not provide such

--- a/docs/guides/hpc_acceleration.rst
+++ b/docs/guides/hpc_acceleration.rst
@@ -4,7 +4,7 @@ Support for multi-process and multi-threaded acceleration
 
 This page documents the extent to which ``qiskit-addon-sqd`` supports
 multi-threaded and multi-process acceleration, and the assumptions that a
-high-performance-computing (HPC) developer may rely on when integrating this
+high-performance-computing (HPC) developer can rely on when integrating this
 package into an accelerated workload.
 
 The single-threaded assumption
@@ -27,7 +27,7 @@ single thread controlling each process (``MPI_THREAD_FUNNELED`` or lower).
 Only one function currently supports being called collectively from all
 processes: :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian`.
 When it is invoked collectively, the eigensolver step is where all processes
-participate and contribute work, so an eigensolver implementation may leverage
+participate and contribute work, so an eigensolver implementation can use
 every process. The remaining parts of the configuration-recovery loop have no
 distributed implementation and run on the control process (rank 0) only.
 
@@ -59,13 +59,13 @@ context collectively (for example, via ``MPI_Abort``).
 
 The API cannot guarantee coordinated error reporting or collective delivery of
 exceptions across processes, because MPI implementations do not provide such
-guarantees. An implementation may additionally attempt to make an error visible
+guarantees. An implementation might additionally attempt to make an error visible
 to all participating processes---for example, by having each process raise an
 exception---but this can only be provided on a best-effort basis and must not be
 relied upon for correctness or recovery.
 
 These are properties that a collective implementation is permitted to have, not
 guarantees about any particular one. In this package, the only collective entry
-point is ``sci_solver`` (see above); its default implementation is not
+point is ``sci_solver`` (see the preceding section); its default implementation is not
 distributed, so these considerations apply to a custom, collective
 ``sci_solver`` supplied by the user.

--- a/docs/guides/hpc_acceleration.rst
+++ b/docs/guides/hpc_acceleration.rst
@@ -33,6 +33,22 @@ API for HPC systems. Regardless of implementation, this package assumes that a
 single thread controls each process. In the case of MPI, this corresponds to
 ``MPI_THREAD_FUNNELED`` or lower.
 
+If a function supports collective execution, its documentation must say so. If the
+documentation does not mention collective execution, the function has no
+collective semantics and must be called from the control process alone.
+
+The specific return-value and synchronization semantics of a collective function
+are documented with the function itself. In general, that documentation should
+make clear:
+
+- Whether the function is meant to be called independently by each process on
+  its own local data, or collectively by all processes.
+- How its arguments must agree across processes.
+- How its return value is delivered---whether the result exists only on the
+  control process, whether all processes receive the same value, or whether
+  each process receives a handle to a local portion of a distributed data
+  structure.
+
 Only one function currently supports being called collectively from all
 processes: :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian`.
 When it is invoked collectively, the eigensolver step is where all processes
@@ -47,19 +63,6 @@ behalf. That mode is convenient for interactive and notebook-based work and
 remains supported; its requirements on the calling program are described in the
 API reference of the
 :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` function.
-
-The return value and synchronization semantics of a collective function
-belong with that function, so they are documented in its API reference.
-In general, the documentation of any collective function
-should make clear:
-
-- Whether the function is meant to be called independently by each process on
-  its own local data, or collectively by all processes.
-- How its arguments must agree across processes.
-- How its return value is delivered---whether the result exists only on the
-  control process, whether all processes receive the same value, or whether
-  each process receives a handle to a local portion of a distributed data
-  structure.
 
 Error handling in a multi-process context
 =========================================

--- a/docs/guides/hpc_acceleration.rst
+++ b/docs/guides/hpc_acceleration.rst
@@ -1,0 +1,71 @@
+##############################################################
+Support for multi-process and multi-threaded acceleration
+##############################################################
+
+This page documents the extent to which ``qiskit-addon-sqd`` supports
+multi-threaded and multi-process acceleration, and the assumptions that a
+high-performance-computing (HPC) developer may rely on when integrating this
+package into an accelerated workload.
+
+The single-threaded assumption
+==============================
+
+Unless otherwise specified, the APIs in this package are meant to be called
+from a single thread. High-level APIs exposed by this package are not
+guaranteed to be re-entrant, and end users should not invoke them from any
+thread other than the main thread.
+
+Collective multi-process execution
+===================================
+
+This package supports collective multi-process acceleration in the
+single-program, multiple-data (SPMD) style, in which the same program runs in
+multiple isolated processes with explicit global synchronization and
+communication between them. The current implementation relies on MPI, with a
+single thread controlling each process (``MPI_THREAD_FUNNELED`` or lower).
+
+Only one function currently supports being called collectively from all
+processes: :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian`.
+When it is invoked collectively, the eigensolver step is where all processes
+participate and contribute work, so an eigensolver implementation may leverage
+every process. The remaining parts of the configuration-recovery loop have no
+distributed implementation and run on the control process (rank 0) only.
+
+Every other API in this package is intended to be called from the control
+process alone, on its own local data, and carries no collective semantics.
+
+The precise return-value and synchronization semantics of a collective function
+belong with that function, so they are documented in its API reference rather
+than repeated here. In general, the documentation of any collective function
+should make clear:
+
+- whether the function is meant to be called independently by each process on
+  its own local data, or collectively by all processes;
+- how its arguments must agree across processes;
+- and how its return value is delivered---whether the result exists only on the
+  control process, whether all processes receive the same value, or whether
+  each process receives a handle to a local portion of a distributed data
+  structure.
+
+Error handling in a multi-process context
+=========================================
+
+A function that is called collectively from all processes must not raise an
+exception or abort only a single process, because that would leave the
+remaining processes deadlocked or in an inconsistent state. Instead, error
+handling follows fail-stop semantics for the execution context as a whole: upon
+an error, the implementation must be prepared to abort the entire execution
+context collectively (for example, via ``MPI_Abort``).
+
+The API cannot guarantee coordinated error reporting or collective delivery of
+exceptions across processes, because MPI implementations do not provide such
+guarantees. An implementation may additionally attempt to make an error visible
+to all participating processes---for example, by having each process raise an
+exception---but this can only be provided on a best-effort basis and must not be
+relied upon for correctness or recovery.
+
+These are properties that a collective implementation is permitted to have, not
+guarantees about any particular one. In this package, the only collective entry
+point is ``sci_solver`` (see above); its default implementation is not
+distributed, so these considerations apply to a custom, collective
+``sci_solver`` supplied by the user.

--- a/docs/guides/hpc_acceleration.rst
+++ b/docs/guides/hpc_acceleration.rst
@@ -19,10 +19,17 @@ Collective multi-process execution
 ===================================
 
 This package supports collective multi-process acceleration in the
-single-program, multiple-data (SPMD) style, in which the same program runs in
-multiple isolated processes with explicit global synchronization and
-communication between them. The current implementation relies on MPI, with a
-single thread controlling each process (``MPI_THREAD_FUNNELED`` or lower).
+single-program, multiple-data (SPMD) style, in which the entire program is
+launched as multiple isolated processes that run with explicit global
+synchronization and communication between them (for example,
+``mpirun -n 128 python my_program.py``). While the API of this package is
+designed to be general, the current implementation relies on MPI,
+the standard message-passing API for HPC systems.  Regardless of implementation,
+this package makes the assumption that there is a single thread controlling
+each process. In the case of MPI, this corresponds to ``MPI_THREAD_FUNNELED`` or lower.
+Because it composes cleanly with job schedulers and other parallel software and
+scales to large process counts, this is the recommended model for
+high-performance and large-scale workloads, and it is the subject of this page.
 
 Only one function currently supports being called collectively from all
 processes: :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian`.
@@ -30,6 +37,14 @@ When it is invoked collectively, the eigensolver step is where all processes
 participate and contribute work, so an eigensolver implementation can use
 every process. The remaining parts of the configuration-recovery loop have no
 distributed implementation and run on the control process (rank 0) only.
+
+Some existing eigensolver implementations instead require the calling program
+to be outside an MPI/SPMD environment, as they launch and manage their own parallel processes internally, for
+example by invoking ``mpirun`` on the user's behalf. That mode is convenient
+for interactive and notebook-based work and remains supported; its requirements
+on the calling program are described in the API reference of the
+:func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` function,
+which accepts such a solver.
 
 Every other API in this package must be called from the control
 process alone, on its own local data, and carries no collective semantics.

--- a/docs/guides/overview.rst
+++ b/docs/guides/overview.rst
@@ -19,6 +19,7 @@ These guides provide a deeper explanation of specific concepts and components fr
 General
 """""""
 - :doc:`How to choose the subspace dimension from its impact on eigenvalue estimation accuracy <choose_subspace_dimension>`
+- :doc:`Understand this package's support for multi-process and multi-threaded acceleration <hpc_acceleration>`
 
 Fermionic systems
 """""""""""""""""
@@ -44,6 +45,7 @@ Spin systems
    :caption: General
 
    Choose the subspace dimension <choose_subspace_dimension>
+   Multi-process and multi-threaded acceleration <hpc_acceleration>
 
 .. toctree::
    :hidden:

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -313,13 +313,12 @@ def diagonalize_fermionic_hamiltonian(
 
         Whether the calling program should be launched under MPI depends on the
         ``sci_solver`` in use. A collective ``sci_solver``, as described above,
-        expects the program to run collectively across all processes. Some
-        ``sci_solver`` implementations instead manage their own parallelism
-        internally (for example, by launching ``mpirun`` themselves), and any
-        ``sci_solver`` that has no distributed implementation runs serially; both
-        of these cases require the calling program to run as a single process,
-        outside any MPI/SPMD environment. The default ``sci_solver`` is not
-        distributed and falls into this latter category.
+        expects the program to run collectively across all processes. Other
+        implementations require the calling program to run as a single process,
+        outside any MPI/SPMD environment.  Some of these implementations might
+        manage their own parallelism internally, for example, by launching
+        ``mpirun`` themselves. The default ``sci_solver`` is not distributed
+        and falls into this latter category.
 
         A collective ``sci_solver`` implementation is not required to raise an
         exception on a single process when it encounters an error; instead, it

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -302,7 +302,7 @@ def diagonalize_fermionic_hamiltonian(
         following semantics apply:
 
         - The ``sci_solver`` step is the only collective operation: all
-          processes participate in it, so an ``sci_solver`` implementation may
+          processes participate in it, so an ``sci_solver`` implementation can
           distribute work across every process. The remaining steps of the
           configuration-recovery loop (preparing the CI strings, processing the
           diagonalization results, and checking convergence) have no distributed
@@ -313,7 +313,7 @@ def diagonalize_fermionic_hamiltonian(
 
         A collective ``sci_solver`` implementation is not required to raise an
         exception on a single process when it encounters an error; instead, it
-        may follow fail-stop semantics for the execution context as a whole,
+        can follow fail-stop semantics for the execution context as a whole,
         aborting all processes collectively. (This describes what such an
         implementation is permitted to do, not the behavior of the default
         ``sci_solver``.)

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -293,6 +293,30 @@ def diagonalize_fermionic_hamiltonian(
 
     Returns:
         The estimate of the energy and the SCI state with that energy.
+
+    Note:
+        This function supports collective multi-process (SPMD) execution using
+        MPI, with a single thread controlling each process
+        (``MPI_THREAD_FUNNELED`` or lower). When it is invoked collectively from
+        all processes, the arguments must agree across processes, and the
+        following semantics apply:
+
+        - The ``sci_solver`` step is the only collective operation: all
+          processes participate in it, so an ``sci_solver`` implementation may
+          distribute work across every process. The remaining steps of the
+          configuration-recovery loop (preparing the CI strings, processing the
+          diagonalization results, and checking convergence) have no distributed
+          implementation and are performed on the control process alone.
+        - The ``callback``, if provided, is invoked on the control process only.
+        - The return value is the same on every process: the final result is
+          broadcast from the control process to all ranks.
+
+        A collective ``sci_solver`` implementation is not required to raise an
+        exception on a single process when it encounters an error; instead, it
+        may follow fail-stop semantics for the execution context as a whole,
+        aborting all processes collectively. (This describes what such an
+        implementation is permitted to do, not the behavior of the default
+        ``sci_solver``.)
     """
     if max_iterations < 1:
         raise ValueError("Maximum number of iterations must be at least 1.")

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -311,6 +311,16 @@ def diagonalize_fermionic_hamiltonian(
         - The return value is the same on every process: the final result is
           broadcast from the control process to all ranks.
 
+        Whether the calling program should be launched under MPI depends on the
+        ``sci_solver`` in use. A collective ``sci_solver``, as described above,
+        expects the program to run collectively across all processes. Some
+        ``sci_solver`` implementations instead manage their own parallelism
+        internally (for example, by launching ``mpirun`` themselves), and any
+        ``sci_solver`` that has no distributed implementation runs serially; both
+        of these cases require the calling program to run as a single process,
+        outside any MPI/SPMD environment. The default ``sci_solver`` is not
+        distributed and falls into this latter category.
+
         A collective ``sci_solver`` implementation is not required to raise an
         exception on a single process when it encounters an error; instead, it
         can follow fail-stop semantics for the execution context as a whole,

--- a/releasenotes/notes/spmd-support-214a17c1c745a761.yaml
+++ b/releasenotes/notes/spmd-support-214a17c1c745a761.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    :func:`qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` can now be
+    called collectively from all processes of a multi-process (SPMD) execution,
+    for example under MPI. When invoked this way, the ``sci_solver`` step runs on
+    every process, so a custom, distributed ``sci_solver`` can spread each
+    diagonalization across the available processes; the rest of the
+    configuration-recovery loop runs on the control process alone, and the return
+    value is the same on every process. Single-process behavior is unchanged. See
+    :doc:`/guides/hpc_acceleration` for details on the package's support for
+    multi-process and multi-threaded acceleration.


### PR DESCRIPTION
This adds a guide about HPC acceleration and modifies the docstring for `diagonalize_fermionic_hamiltonian` with details of its support for SPMD.

Some text was generated by Claude Opus 4.8 and edited by hand.

Fixes #331.