### PR TITLE
Document that symmetrize_spin does not constrain the spin of the returned state

### DIFF
--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -271,7 +271,6 @@ def diagonalize_fermionic_hamiltonian(
         symmetrize_spin: Whether to always merge spin-alpha and spin-beta CI strings
             into a single list, so that the diagonalization subspace is invariant with
             respect to the exchange of spin alpha with spin beta.
-            
             This affects only which determinants span the diagonalization subspace.
             It does not impose or improve the total spin of the returned state. To
             target a spin sector, pass a solver carrying a spin constraint, for

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -271,6 +271,13 @@ def diagonalize_fermionic_hamiltonian(
         symmetrize_spin: Whether to always merge spin-alpha and spin-beta CI strings
             into a single list, so that the diagonalization subspace is invariant with
             respect to the exchange of spin alpha with spin beta.
+            
+            This affects only which determinants span the diagonalization subspace.
+            It does not impose or improve the total spin of the returned state. To
+            target a spin sector, pass a solver carrying a spin constraint, for
+            example ``functools.partial(solve_sci_batch, spin_sq=0.0)``, as
+            ``sci_solver``. ``SCIState.spin_square()`` reports the total spin squared
+            of the state actually returned.
         max_dim: Limit on the dimension of the spin sectors of the SCI subspace.
             It can be either:
 

--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -272,11 +272,7 @@ def diagonalize_fermionic_hamiltonian(
             into a single list, so that the diagonalization subspace is invariant with
             respect to the exchange of spin alpha with spin beta.
             This affects only which determinants span the diagonalization subspace.
-            It does not impose or improve the total spin of the returned state. To
-            target a spin sector, pass a solver carrying a spin constraint, for
-            example ``functools.partial(solve_sci_batch, spin_sq=0.0)``, as
-            ``sci_solver``. ``SCIState.spin_square()`` reports the total spin squared
-            of the state actually returned.
+            It does not impose or improve the total spin of the returned state.
         max_dim: Limit on the dimension of the spin sectors of the SCI subspace.
             It can be either:
 


### PR DESCRIPTION
Follow-up to [#337](https://github.com/Qiskit/qiskit-addon-sqd/issues/337). Two sentences added to the symmetrize_spin docstring entry in diagonalize_fermionic_hamiltonian. No behavior change, no code touched.

The existing sentence is accurate about the mechanism. What it does not say is what the flag leaves alone, which is what I misread: the parameter name and the "spin symmetrization" wording in the argument checks read to me as a statement about the spin of the result. This adds that, in the maintainer's own framing from [#337](https://github.com/Qiskit/qiskit-addon-sqd/issues/337).

The follow-on paragraph inside the Args entry matches the existing max_dim entry, which already uses one.

The functools.partial(solve_sci_batch, spin_sq=0.0) sentence is severable. It records the answer to question 2 in [#337](https://github.com/Qiskit/qiskit-addon-sqd/issues/337), which is still open. If that is not the intended pattern, tell me what is and I will replace it; or drop that one sentence and the rest stands on its own.

No release note: docs-only, no behavior change. Happy to add one if you would rather have it.