### PR TITLE
broken links

### DIFF
--- a/releasenotes/notes/0.11/run_sqd_fermion-99f3a73a557f4f64.yaml
+++ b/releasenotes/notes/0.11/run_sqd_fermion-99f3a73a557f4f64.yaml
@@ -2,5 +2,3 @@
 features:
   - |
     Added a new function :func:`qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` to serve as the main entrypoint to the SQD algorithm.
-    See the updated `tutorials <https://qiskit.github.io/qiskit-addon-sqd/tutorials/index.html>`_ for a demonstration of how
-    to use this function.

--- a/releasenotes/notes/0.13/spmd-support-214a17c1c745a761.yaml
+++ b/releasenotes/notes/0.13/spmd-support-214a17c1c745a761.yaml
@@ -8,5 +8,5 @@ features:
     diagonalization across the available processes; the rest of the
     configuration-recovery loop runs on the control process alone, and the return
     value is the same on every process. Single-process behavior is unchanged. See
-    `this guide <https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd/guides/hpc-acceleration>` for details on the package's support for
+    `this guide <https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd/guides/hpc-acceleration>`_ for details on the package's support for
     multi-process and multi-threaded acceleration.

--- a/releasenotes/notes/0.13/spmd-support-214a17c1c745a761.yaml
+++ b/releasenotes/notes/0.13/spmd-support-214a17c1c745a761.yaml
@@ -8,5 +8,5 @@ features:
     diagonalization across the available processes; the rest of the
     configuration-recovery loop runs on the control process alone, and the return
     value is the same on every process. Single-process behavior is unchanged. See
-    `this guide <https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd/guides/hpc-acceleration>`__ for details on the package's support for
+    `this guide <https://quantum.cloud.ibm.com/docs/addons/qiskit-addon-sqd/guides/hpc-acceleration>` for details on the package's support for
     multi-process and multi-threaded acceleration.


### PR DESCRIPTION
cc:  @garrison 
- Removing a link that no longer exists from v0.11 release notes (lmk if there is a better link to use rather than removing it)
- Testing what happens with the single underscore vs. double, since the link did not translate properly through our pipeline