### PR TITLE
Enable coverage CI workflow and set fail-under to 75%

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,45 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - main
+      - 'stable/**'
+  pull_request:
+    branches:
+      - main
+      - 'stable/**'
+  merge_group:
+
+jobs:
+  coverage:
+    name: code coverage (${{ matrix.os }}, ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox coverage
+      - name: Run coverage
+        run: |
+          tox -e coverage
+      - name: Convert to lcov
+        if: always()
+        run: python -m coverage lcov -o coveralls.lcov
+      - name: Upload report to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coveralls.lcov
+          format: lcov

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   [![License](https://img.shields.io/github/license/Qiskit/qiskit-addon-sqd?label=License)](LICENSE.txt)
   [![Downloads](https://img.shields.io/pypi/dm/qiskit-addon-sqd.svg?label=Downloads)](https://pypi.org/project/qiskit-addon-sqd/)
   [![Tests](https://github.com/Qiskit/qiskit-addon-sqd/actions/workflows/test_latest_versions.yml/badge.svg)](https://github.com/Qiskit/qiskit-addon-sqd/actions/workflows/test_latest_versions.yml)
+  [![Coverage](https://coveralls.io/repos/github/Qiskit/qiskit-addon-sqd/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-addon-sqd?branch=main)
 
 # Sample-based quantum diagonalization (SQD)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ branch = true
 parallel = true
 
 [tool.coverage.report]
-fail_under = 100
+fail_under = 75
 show_missing = true
 
 [tool.hatch.build.targets.wheel]

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands =
   coverage3 run --source qiskit_addon_sqd --parallel-mode -m pytest test/ {posargs}
   coverage3 combine
   coverage3 html
-  coverage3 report --fail-under=100 --show-missing
+  coverage3 report --fail-under=75 --show-missing
 
 [testenv:docs]
 basepython = python3.10


### PR DESCRIPTION
This PR was generated by Claude Opus 5 under my guidance.

<hr>

### Enable the coverage workflow

`.github/workflows/README.md` has documented a `coverage.yml` workflow all along, but the workflow file itself was never actually added to this repo — so `tox -e coverage` has never run in CI here. This brings the workflow over from `qiskit-addon-utils` verbatim, along with the matching Coveralls badge in the README.

### Lower `fail_under` from 100 to 75

Coverage currently sits at **77%**, so a `fail_under` of 100 was unachievable and the environment would have failed immediately on being enabled. Lowering the threshold to 75% in both `tox.ini` and `pyproject.toml` makes the workflow reflect the actual state of the test suite while still guarding against regressions from here.

Current per-module breakdown:

```
Name                                         Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------------------
qiskit_addon_sqd/__init__.py                     0      0      0      0   100%
qiskit_addon_sqd/configuration_recovery.py      78      0     26      2    98%
qiskit_addon_sqd/counts.py                      67      0     24      0   100%
qiskit_addon_sqd/fermion.py                    344    121     76     11    61%
qiskit_addon_sqd/processes.py                   41     13      6      2    64%
qiskit_addon_sqd/qubit.py                       59      0     10      0   100%
qiskit_addon_sqd/subsampling.py                 58      3     28      3    93%
------------------------------------------------------------------------------
TOTAL                                          647    137    170     18    77%
```

`fermion.py` and `processes.py` are where the gap lives. Raising the threshold back toward 100 is worth doing incrementally as those get covered, but that's out of scope here.

### Note on the badge

The Coveralls badge (and the upload step at the end of the workflow) will only render real numbers once the Coveralls integration is enabled for `Qiskit/qiskit-addon-sqd`. Until then the badge will show "unknown" — the upload step is `if: always()` and won't fail the job.
