### PR TITLE
Guard the unconditional pyscf import in fermion.py

### DIFF
--- a/qiskit_addon_sqd/fermion.py
+++ b/qiskit_addon_sqd/fermion.py
@@ -22,15 +22,6 @@ import numpy as np
 from jax import Array, config, grad, jit, vmap
 from jax import numpy as jnp
 from jax.scipy.linalg import expm
-from pyscf import fci
-from pyscf.fci.selected_ci import (
-    _as_SCIvector,
-    make_rdm1,
-    make_rdm1s,
-    make_rdm2,
-    make_rdm2s,
-    spin_square,
-)
 from qiskit.primitives import BitArray
 from qiskit.utils.deprecation import deprecate_func
 from scipy import linalg as LA
@@ -39,6 +30,41 @@ from .configuration_recovery import recover_configurations
 from .counts import bit_array_to_arrays, bitstring_matrix_to_integers
 from .processes import broadcast, is_control_process
 from .subsampling import postselect_by_hamming_right_and_left, subsample
+
+try:
+    from pyscf import fci
+    from pyscf.fci.selected_ci import (
+        _as_SCIvector,
+        make_rdm1,
+        make_rdm1s,
+        make_rdm2,
+        make_rdm2s,
+        spin_square,
+    )
+
+    _HAS_PYSCF = True
+except ImportError:
+    _HAS_PYSCF = False
+
+
+def _require_pyscf() -> None:
+    """Raise a clear error if pyscf, an optional dependency, is not available.
+
+    pyscf does not currently provide prebuilt wheels for Windows (see
+    https://github.com/Qiskit/qiskit-addon-sqd/issues/349), so this module must
+    remain importable without it; only the functions that actually need pyscf's
+    selected-CI solver should fail, and only once called.
+    """
+    if not _HAS_PYSCF:
+        raise ImportError(
+            "This functionality requires the 'pyscf' package, which could not be "
+            "imported (it is not installed, or not available on this platform -- "
+            "e.g. pyscf does not currently provide prebuilt wheels for Windows). "
+            "Install pyscf to use this function, or, if calling "
+            "`diagonalize_fermionic_hamiltonian`, pass a custom `sci_solver` that "
+            "does not depend on pyscf."
+        )
+
 
 config.update("jax_enable_x64", True)  # To deal with large integers
 
@@ -112,6 +138,7 @@ class SCIState:
 
     def rdm(self, rank: int = 1, spin_summed: bool = False) -> np.ndarray:
         """Compute reduced density matrix."""
+        _require_pyscf()
         # Reason for type: ignore: mypy can't tell the return type of the
         # PySCF functions
         sci_vector = _as_SCIvector(self.amplitudes, (self.ci_strs_a, self.ci_strs_b))
@@ -129,6 +156,7 @@ class SCIState:
 
     def spin_square(self) -> float:
         """Return spin squared."""
+        _require_pyscf()
         sci_vector = _as_SCIvector(self.amplitudes, (self.ci_strs_a, self.ci_strs_b))
         spin_squared, _ = spin_square(sci_vector, norb=self.norb, nelec=self.nelec)
         return cast(float, spin_squared)
@@ -708,6 +736,7 @@ def solve_sci(
     Returns:
         The diagonalization result.
     """
+    _require_pyscf()
     norb, _ = one_body_tensor.shape
 
     myci = fci.selected_ci.SelectedCI()
@@ -786,6 +815,7 @@ def solve_fermion(
         - Expectation value of spin-squared
 
     """
+    _require_pyscf()
     # Format inputs
     if isinstance(bitstring_matrix, tuple):
         ci_strs = bitstring_matrix
@@ -907,6 +937,7 @@ def optimize_orbitals(
         - Tuple containing orbital occupancies for spin-up and spin-down orbitals. Formatted as: ``(array([occ_a_0, ..., occ_a_N]), array([occ_b_0, ..., occ_b_N]))``
 
     """
+    _require_pyscf()
     norb = hcore.shape[0]
     num_params = (norb**2 - norb) // 2
     if len(k_flat) != num_params:

--- a/releasenotes/notes/guard-pyscf-import-fermion-4f6b6e7a8c9d0e1f.yaml
+++ b/releasenotes/notes/guard-pyscf-import-fermion-4f6b6e7a8c9d0e1f.yaml
@@ -1,0 +1,16 @@
+---
+fixes:
+  - |
+    :mod:`qiskit_addon_sqd.fermion` no longer fails to import when ``pyscf`` is
+    unavailable (e.g. on Windows, where ``pyscf`` provides no prebuilt wheels).
+    Only the functions that actually require ``pyscf``'s selected-CI solver --
+    :func:`~qiskit_addon_sqd.fermion.solve_sci`,
+    :func:`~qiskit_addon_sqd.fermion.solve_fermion`,
+    :func:`~qiskit_addon_sqd.fermion.optimize_orbitals`, and the
+    :meth:`~qiskit_addon_sqd.fermion.SCIState.rdm` and
+    :meth:`~qiskit_addon_sqd.fermion.SCIState.spin_square` methods -- now raise
+    a clear ``ImportError`` if called without ``pyscf`` installed, instead of
+    the whole module failing to import. This also means
+    :func:`~qiskit_addon_sqd.fermion.diagonalize_fermionic_hamiltonian` can now
+    be used on such platforms when passed a custom ``sci_solver`` that does not
+    depend on ``pyscf``.

--- a/test/test_fermion.py
+++ b/test/test_fermion.py
@@ -16,6 +16,8 @@ import importlib
 import math
 import sys
 import unittest
+import unittest.mock
+import warnings
 
 import numpy as np
 import pytest
@@ -440,3 +442,64 @@ def test_require_pyscf_is_a_noop_when_available():
     from qiskit_addon_sqd.fermion import _require_pyscf
 
     _require_pyscf()  # must not raise
+
+
+class TestPyscfGuardWiring(unittest.TestCase):
+    """Each pyscf-dependent public entry point must actually call ``_require_pyscf()``
+    before touching any pyscf-only name, not just have the helper exist and work in
+    isolation. Every case below is run with ``_HAS_PYSCF`` patched to ``False``
+    regardless of whether pyscf is really installed in this environment, so a
+    regression here (e.g. a future edit moving or removing the guard call) is
+    caught even in CI where pyscf *is* present -- garbage/minimal arguments are
+    used throughout, since the guard must fire before any of them are used.
+    """
+
+    def setUp(self):
+        import qiskit_addon_sqd.fermion as fermion_module
+
+        self.fermion_module = fermion_module
+        patcher = unittest.mock.patch.object(fermion_module, "_HAS_PYSCF", False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.sci_state = SCIState(
+            amplitudes=np.array([[0.5, 0.5], [0.5, 0.5]]),
+            ci_strs_a=np.array([0b0011, 0b0101]),
+            ci_strs_b=np.array([0b0011, 0b0101]),
+            norb=4,
+            nelec=(2, 2),
+        )
+
+    def test_sci_state_rdm_requires_pyscf(self):
+        with self.assertRaisesRegex(ImportError, "pyscf"):
+            self.sci_state.rdm()
+
+    def test_sci_state_spin_square_requires_pyscf(self):
+        with self.assertRaisesRegex(ImportError, "pyscf"):
+            self.sci_state.spin_square()
+
+    def test_solve_sci_requires_pyscf(self):
+        with self.assertRaisesRegex(ImportError, "pyscf"):
+            self.fermion_module.solve_sci(None, None, None, norb=None, nelec=None)
+
+    def test_solve_sci_batch_requires_pyscf(self):
+        # `solve_sci_batch` has no pyscf usage of its own; it must still fail
+        # (transitively, via `solve_sci`) rather than proceed into real pyscf calls.
+        with self.assertRaisesRegex(ImportError, "pyscf"):
+            self.fermion_module.solve_sci_batch(
+                [(np.array([0b0011]), np.array([0b0011]))], None, None, norb=None, nelec=None
+            )
+
+    def test_solve_fermion_requires_pyscf(self):
+        with self.assertRaisesRegex(ImportError, "pyscf"):
+            self.fermion_module.solve_fermion((np.array([0b0011]), np.array([0b0011])), None, None)
+
+    def test_optimize_orbitals_requires_pyscf(self):
+        # `optimize_orbitals` is `@deprecate_func`-decorated; suppress that unrelated
+        # warning so it doesn't fail the test under `-W error`.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            with self.assertRaisesRegex(ImportError, "pyscf"):
+                self.fermion_module.optimize_orbitals(
+                    (np.array([0b0011]), np.array([0b0011])), None, None, np.array([])
+                )

--- a/test/test_fermion.py
+++ b/test/test_fermion.py
@@ -12,14 +12,13 @@
 
 """Tests for the fermion module."""
 
+import importlib
 import math
+import sys
 import unittest
 
 import numpy as np
-import pyscf
-import pyscf.mcscf
 import pytest
-from pyscf.fci import cistring, spin_square
 from qiskit.primitives import BitArray
 from qiskit_addon_sqd.counts import generate_bit_array_uniform
 from qiskit_addon_sqd.fermion import (
@@ -27,6 +26,19 @@ from qiskit_addon_sqd.fermion import (
     bitstring_matrix_to_ci_strs,
     diagonalize_fermionic_hamiltonian,
 )
+
+try:
+    import pyscf
+    import pyscf.mcscf
+    from pyscf.fci import cistring, spin_square
+
+    _HAS_PYSCF = True
+except ImportError:
+    # pyscf provides no prebuilt wheels for some platforms (e.g. Windows), where
+    # it is not installed as a dependency at all -- see #349. The tests below
+    # that actually need it are skipped in that case (see `TestFermion`); the
+    # tests for the import guard itself must still be collectible and runnable.
+    _HAS_PYSCF = False
 
 
 def _sci_vec_to_fci_vec(
@@ -47,6 +59,7 @@ def _sci_vec_to_fci_vec(
     return fci_vec.reshape(-1)
 
 
+@unittest.skipUnless(_HAS_PYSCF, "requires pyscf")
 class TestFermion(unittest.TestCase):
     def setUp(self):
         self.rng = np.random.default_rng(190560294508743238113331500595174898458)
@@ -380,3 +393,50 @@ def test_sci_state_save_load(tmp_path):
     np.testing.assert_array_equal(loaded_state.ci_strs_b, sci_state.ci_strs_b)
     assert loaded_state.norb == sci_state.norb
     assert loaded_state.nelec == sci_state.nelec
+
+
+def test_fermion_importable_without_pyscf(monkeypatch):
+    """``qiskit_addon_sqd.fermion`` must remain importable without pyscf installed.
+
+    pyscf provides no prebuilt wheels for some platforms (e.g. Windows), so an
+    unguarded top-level ``from pyscf import ...`` prevents the whole module -- not
+    just its pyscf-dependent functions -- from being imported there. See #349.
+    """
+    import qiskit_addon_sqd.fermion as fermion_module
+
+    for name in list(sys.modules):
+        if name == "pyscf" or name.startswith("pyscf."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    # Setting a module to `None` in `sys.modules` makes `import` raise
+    # `ImportError` for it, simulating pyscf being genuinely unavailable.
+    monkeypatch.setitem(sys.modules, "pyscf", None)
+
+    try:
+        reloaded = importlib.reload(fermion_module)
+        assert reloaded._HAS_PYSCF is False
+        with pytest.raises(ImportError, match="pyscf"):
+            reloaded._require_pyscf()
+    finally:
+        # Restore the module to its normal state before any other test relies
+        # on `qiskit_addon_sqd.fermion` working normally -- `monkeypatch` will
+        # restore `sys.modules` itself, but only *after* this test returns.
+        monkeypatch.undo()
+        importlib.reload(fermion_module)
+    assert fermion_module._HAS_PYSCF is _HAS_PYSCF
+
+
+def test_require_pyscf_raises_a_clear_error(monkeypatch):
+    """``_require_pyscf`` raises a clear, actionable error when pyscf is unavailable."""
+    import qiskit_addon_sqd.fermion as fermion_module
+
+    monkeypatch.setattr(fermion_module, "_HAS_PYSCF", False)
+    with pytest.raises(ImportError, match="pyscf"):
+        fermion_module._require_pyscf()
+
+
+@unittest.skipUnless(_HAS_PYSCF, "requires pyscf")
+def test_require_pyscf_is_a_noop_when_available():
+    """``_require_pyscf`` does nothing when pyscf is actually available."""
+    from qiskit_addon_sqd.fermion import _require_pyscf
+
+    _require_pyscf()  # must not raise


### PR DESCRIPTION
Fixes #349.

`pyproject.toml` already marks `pyscf` as `sys_platform != 'win32'` -- the packaging side already anticipated Windows users not having it -- but `fermion.py`'s top-level `from pyscf import ...` was never updated to match, so importing the module (and anything that imports it) crashed outright on Windows with `ModuleNotFoundError`, rather than only the functions that actually need pyscf's selected-CI solver.

The pyscf-related imports are now wrapped in `try/except`, and a small `_require_pyscf()` helper raises a clear, actionable `ImportError` from each function that actually needs pyscf (`solve_sci`, `solve_fermion`, `optimize_orbitals`, `SCIState.rdm`, `SCIState.spin_square`) when called without it installed. `diagonalize_fermionic_hamiltonian`'s existing pluggable `sci_solver` mechanism already lets a caller supply a non-pyscf solver, so that entry point now genuinely works on such platforms too, per the issue's own framing.

## Testing

- `test/test_fermion.py`'s own top-level pyscf imports are guarded the same way, and `TestFermion` (whose every method needs a real pyscf computation) is skipped rather than making the whole test module fail to collect when pyscf is unavailable.
- 3 tests for the import guard itself (`test_fermion_importable_without_pyscf`, `test_require_pyscf_raises_a_clear_error`, `test_require_pyscf_is_a_noop_when_available`).
- `TestPyscfGuardWiring` -- 6 tests confirming each of the 5 real call sites (plus `solve_sci_batch`, transitively) actually invokes the guard, not just the helper in isolation.
- Verified live on Windows, where pyscf genuinely cannot be installed here (no C/C++ compiler): `import qiskit_addon_sqd.fermion` crashed before this change and imports cleanly after it -- not a simulated scenario.
- Full local suite: 23 passed, 7 skipped (pyscf-dependent tests, this machine has no pyscf), 0 failures. `ruff check`/`format --check` clean.
- Release note added under `releasenotes/notes/` (`reno` convention, `fixes` category).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
